### PR TITLE
Export of Chat from the ChatView

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ These entries are mandatory for apps that utilize microphone and speech recognit
 ### Chat View
 
 The [`ChatView`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatview) provides a basic reusable chat view which includes a message input field. The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
+In addition, the [`ChatView`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatview) provides functionality to export the visualized [`Chat`](https://swiftpackageindex.com/stanfordspezi/spezichat/0.1.1/documentation/spezichat/chat) as a PDF document, JSON representation, or textual UTF-8 file (see `ChatView/ChatExportFormat`) via a Share Sheet (or Activity View).
 
 ```swift
 struct ChatTestView: View {
@@ -66,7 +67,7 @@ struct ChatTestView: View {
 
 
     var body: some View {
-        ChatView($chat)
+        ChatView($chat, exportFormat: .pdf)
             .navigationTitle("SpeziChat")
     }
 }

--- a/Sources/SpeziChat/ChatView+Export.swift
+++ b/Sources/SpeziChat/ChatView+Export.swift
@@ -13,7 +13,7 @@ import SwiftUI
 
 
 extension ChatView {
-    /// Output format of the exported ``Chat`` via a share button in the ``ChatView``.
+    /// Output format of the to-be exported ``Chat``.
     public enum ChatExportFormat {
         /// JSON representation of the ``Chat``
         case json
@@ -31,7 +31,7 @@ extension ChatView {
         
         
         var body: some View {
-            VStack(spacing: 8) {    // Sadly, the SwiftUI `ImageRenderer` doesn't support SwiftUI `List`s
+            VStack(spacing: 8) {    // The SwiftUI `ImageRenderer` doesn't support SwiftUI `List`s
                 ForEach(chat, id: \.self) { chatEntity in
                     HStack {
                         if chatEntity.alignment == .trailing {
@@ -50,7 +50,6 @@ extension ChatView {
                             Spacer(minLength: 32)
                         }
                     }
-                     
                 }
                 
                 Spacer()
@@ -120,7 +119,7 @@ extension ChatView {
         // Width from US Letter, height requested by the view
         // Reason: Splitting a view in multiple PDF pages is complex!
         let size = CGSize(
-            width: 72 * 8.5,
+            width: 72 * 8.5,    // US Letter width
             height: proposedHeight
         )
          

--- a/Sources/SpeziChat/ChatView+Export.swift
+++ b/Sources/SpeziChat/ChatView+Export.swift
@@ -1,0 +1,166 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import os
+import PDFKit
+import SwiftUI
+
+
+extension ChatView {
+    /// Output format of the exported ``Chat`` via a share button in the ``ChatView``.
+    public enum ChatExportFormat {
+        /// JSON representation of the ``Chat``
+        case json
+        /// Textual UTF-8 version of the ``Chat``
+        case text
+        /// Rendered PDF document of the ``Chat``
+        case pdf
+    }
+    
+    
+    /// As the ``ChatView`` and the ``MessagesView`` include elements that are not supported by the SwiftUI `ImageRenderer`,
+    /// the `ChatExportPDFView` serves as a simplified intermediary layer for the export of the ``Chat`` to a PDF.
+    private struct ChatExportPDFView: View {
+        let chat: Chat
+        
+        
+        var body: some View {
+            VStack(spacing: 8) {    // Sadly, the SwiftUI `ImageRenderer` doesn't support SwiftUI `List`s
+                ForEach(chat, id: \.self) { chatEntity in
+                    HStack {
+                        if chatEntity.alignment == .trailing {
+                            Spacer(minLength: 32)
+                        }
+                        VStack(alignment: chatEntity.alignment == .leading ? .leading : .trailing) {
+                            Text(chatEntity.content)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .chatMessageStyle(alignment: chatEntity.alignment)
+                            
+                            Text("\(chatEntity.role.rawValue.capitalized): \(chatEntity.date.formatted())")
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                        }
+                        if chatEntity.alignment == .leading {
+                            Spacer(minLength: 32)
+                        }
+                    }
+                     
+                }
+                
+                Spacer()
+            }
+                .padding()
+        }
+    }
+    
+    
+    private static let logger = Logger(subsystem: "edu.stanford.spezi", category: "SpeziChat")
+    private static let encoder: JSONEncoder = {
+        let jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = .prettyPrinted
+        jsonEncoder.dateEncodingStrategy = .iso8601
+        return jsonEncoder
+    }()
+    
+
+    /// Chat exported as `Data` in the format specified by ``ChatView/ChatExportFormat``
+    @MainActor var exportedChatData: Data? {
+        switch exportFormat {
+        case .json: jsonChatData
+        case .text: textChatData
+        case .pdf: pdfChatData
+        case .none: nil
+        }
+    }
+    
+    /// Exported chat encoded as JSON
+    private var jsonChatData: Data? {
+        guard let jsonData = try? Self.encoder.encode(chat) else {
+            Self.logger.error("The to be exported chat couldn't be encoded to JSON format!")
+            return nil
+        }
+        
+        return jsonData
+    }
+    
+    /// Exported chat encoded as a textual UTF-8
+    private var textChatData: Data? {
+        let textData = chat.map {
+            // Format: <ROLE> (<DATE>): <CONTENT>
+            "\($0.role.rawValue.capitalized) (\($0.date.formatted())): \($0.content)"
+        }
+            .joined(separator: "\n")
+            .data(using: .utf8)
+        
+        guard let textData else {
+            Self.logger.error("The to be exported chat couldn't be encoded in a textual UTF-8 format!")
+            return nil
+        }
+        
+        return textData
+    }
+    
+    /// Exported chat rendered as a PDF
+    @MainActor private var pdfChatData: Data? {
+        let renderer = ImageRenderer(content: ChatExportPDFView(chat: chat))
+
+        guard let proposedHeight = renderer.uiImage?.size.height else {
+            Self.logger.error("""
+            The to be exported chat couldn't be rendered as a PDF as the height of the rendered page couldn't be determined!
+            """)
+            return nil
+        }
+        
+        // Width from US Letter, height requested by the view
+        // Reason: Splitting a view in multiple PDF pages is complex!
+        let size = CGSize(
+            width: 72 * 8.5,
+            height: proposedHeight
+        )
+         
+        renderer.proposedSize = .init(size)
+        
+        // Need to fetch page height again as it is adjusted after setting the `proposedSize` on the `ImageRenderer`
+        guard let proposedHeight = renderer.uiImage?.size.height else {
+            Self.logger.error("""
+            The to be exported chat couldn't be rendered as a PDF as the height of the rendered page couldn't be determined!
+            """)
+            return nil
+        }
+        
+        var pdfData: Data?
+        
+        renderer.render { _, context in
+            var box = CGRect(
+                origin: .zero,
+                size: .init(width: size.width, height: proposedHeight)
+            )
+            
+            guard let mutableData = CFDataCreateMutable(kCFAllocatorDefault, 0),
+                  let consumer = CGDataConsumer(data: mutableData),
+                  let pdf = CGContext(consumer: consumer, mediaBox: &box, nil) else {
+                Self.logger.error("The to be exported chat couldn't be rendered as a PDF!")
+                pdfData = nil
+                return
+            }
+            
+            pdf.beginPDFPage(nil)
+            pdf.translateBy(x: 0, y: 0)
+            
+            context(pdf)
+            
+            pdf.endPDFPage()
+            pdf.closePDF()
+            
+            pdfData = PDFDocument(data: mutableData as Data)?.dataRepresentation()
+        }
+        
+        return pdfData
+    }
+}

--- a/Sources/SpeziChat/ChatView+ShareSheet.swift
+++ b/Sources/SpeziChat/ChatView+ShareSheet.swift
@@ -11,13 +11,15 @@ import SwiftUI
 
 
 extension ChatView {
+    /// Provides an iOS-typical Share Sheet (also called Activity View: https://developer.apple.com/design/human-interface-guidelines/activity-views) SwiftUI wrapper 
+    /// for exporting the ``Chat`` content of the ``ChatView`` without the downsides of the SwiftUI `ShareLink` such as unnecessary reevaluations of the to-be shared content.
     struct ShareSheet: UIViewControllerRepresentable {
         let sharedItem: Data
         let sharedItemType: ChatExportFormat
 
         
         func makeUIViewController(context: Context) -> UIActivityViewController {
-            /// Note: Need to write down the data to storage as in-memory PDFs are not recognized properly
+            // Note: Need to write down the data to storage as in-memory shared content is not recognized properly (e.g., PDFs)
             var temporaryPath = FileManager.default.temporaryDirectory.appendingPathComponent("Exported Chat")
             
             switch sharedItemType {
@@ -25,6 +27,7 @@ extension ChatView {
             case .text: temporaryPath = temporaryPath.appendingPathExtension("txt")
             case .pdf: temporaryPath = temporaryPath.appendingPathExtension("pdf")
             }
+            
             try? sharedItem.write(to: temporaryPath)
             
             let controller = UIActivityViewController(

--- a/Sources/SpeziChat/ChatView+ShareSheet.swift
+++ b/Sources/SpeziChat/ChatView+ShareSheet.swift
@@ -1,0 +1,43 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SwiftUI
+
+
+extension ChatView {
+    struct ShareSheet: UIViewControllerRepresentable {
+        let sharedItem: Data
+        let sharedItemType: ChatExportFormat
+
+        
+        func makeUIViewController(context: Context) -> UIActivityViewController {
+            /// Note: Need to write down the data to storage as in-memory PDFs are not recognized properly
+            var temporaryPath = FileManager.default.temporaryDirectory.appendingPathComponent("Exported Chat")
+            
+            switch sharedItemType {
+            case .json: temporaryPath = temporaryPath.appendingPathExtension("json")
+            case .text: temporaryPath = temporaryPath.appendingPathExtension("txt")
+            case .pdf: temporaryPath = temporaryPath.appendingPathExtension("pdf")
+            }
+            try? sharedItem.write(to: temporaryPath)
+            
+            let controller = UIActivityViewController(
+                activityItems: [temporaryPath],
+                applicationActivities: nil
+            )
+            controller.completionWithItemsHandler = { _, _, _, _ in
+                try? FileManager.default.removeItem(at: temporaryPath)
+            }
+            
+            return controller
+        }
+
+        func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+    }
+}

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -54,9 +54,9 @@ import SwiftUI
 /// }
 /// ```
 public struct ChatView: View {
-    let exportFormat: ChatExportFormat?
     @Binding var chat: Chat
     @Binding var disableInput: Bool
+    let exportFormat: ChatExportFormat?
     let messagePlaceholder: String?
     
     @State var messageInputHeight: CGFloat = 0

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -60,7 +60,7 @@ public struct ChatView: View {
     let messagePlaceholder: String?
     
     @State var messageInputHeight: CGFloat = 0
-    @State private var showShareSheet: Bool = false
+    @State private var showShareSheet = false
     
     
     public var body: some View {
@@ -108,6 +108,7 @@ public struct ChatView: View {
             } else {
                 ProgressView()
                     .padding()
+                    .presentationDetents([.medium])
             }
         }
     }

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -144,7 +144,7 @@ public struct ChatView: View {
             ChatEntity(role: .system, content: "System Message (hidden)!"),
             ChatEntity(role: .user, content: "User Message!"),
             ChatEntity(role: .assistant, content: "Assistant Message!"),
-            ChatEntity(role: .function, content: "Function Message!")
+            ChatEntity(role: .function(name: "test_function"), content: "Function Message!")
         ]
     ))
 }

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -14,6 +14,10 @@ import SwiftUI
 /// The actual content of the ``ChatView`` is defined by a ``Chat``, which contains an ordered array of ``ChatEntity``s representing the individual messages within the ``ChatView``.
 /// The ``Chat`` is passed to the ``ChatView`` as a SwiftUI `Binding`, which enables modification of the ``Chat`` from outside of the view, for example via a SwiftUI `.onChange()` `View` modifier.
 ///
+/// ### Usage
+///
+/// A minimal example of the ``ChatView`` can be found below.
+/// Ensure that the `ChatTestView` is wrapped within a SwiftUI `NavigationStack` in order to specify the `.navigationTitle()` view modifier.
 ///
 /// ```swift
 /// struct ChatTestView: View {
@@ -27,12 +31,36 @@ import SwiftUI
 ///     }
 /// }
 /// ```
+///
+/// ### Export of Chat
+///
+/// The ``ChatView`` provides functionality to export the visualized ``Chat`` as a PDF document, JSON representation, or textual UTF-8 file (see ``ChatView/ChatExportFormat``).
+/// The export is enabled via an iOS-typical Share Sheet (also called Activity View: https://developer.apple.com/design/human-interface-guidelines/activity-views)
+/// that is trigged by a click on the Share `Botton` in the `.toolbar()`.
+///
+/// A minimal example enabling the export of the ``Chat`` as a PDF document looks like the following.
+/// Ensure that the `ChatExportTestView` is wrapped within a SwiftUI `NavigationStack`.
+///
+/// ```swift
+/// struct ChatExportTestView: View {
+///     @State private var chat: Chat = [
+///         // ...
+///     ]
+///
+///     var body: some View {
+///         ChatView($chat, exportFormat: .pdf)
+///             .navigationTitle("SpeziChat")
+///     }
+/// }
+/// ```
 public struct ChatView: View {
+    let exportFormat: ChatExportFormat?
     @Binding var chat: Chat
     @Binding var disableInput: Bool
     let messagePlaceholder: String?
     
     @State var messageInputHeight: CGFloat = 0
+    @State private var showShareSheet: Bool = false
     
     
     public var body: some View {
@@ -59,20 +87,50 @@ public struct ChatView: View {
                     }
             }
         }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(action: {
+                    showShareSheet = true
+                }) {
+                    Image(systemName: "square.and.arrow.up")
+                        .accessibilityLabel(Text("EXPORT_CHAT_BUTTON", bundle: .module))
+                        .opacity(exportEnabled ? 1.0 : 0.0)
+                        .scaleEffect(exportEnabled ? 1.0 : 0.8)
+                        .animation(.easeInOut, value: exportEnabled)
+                        .disabled(!exportEnabled)
+                }
+            }
+        }
+        .sheet(isPresented: $showShareSheet) {
+            if let exportedChatData, let exportFormat {
+                ShareSheet(sharedItem: exportedChatData, sharedItemType: exportFormat)
+                    .presentationDetents([.medium])
+            } else {
+                ProgressView()
+                    .padding()
+            }
+        }
+    }
+    
+    private var exportEnabled: Bool {
+        exportFormat != nil && !chat.isEmpty
     }
     
     
     /// - Parameters:
     ///   - chat: The chat that should be displayed.
     ///   - disableInput: Flag if the input view should be disabled.
+    ///   - exportFormat: If specified, enables the export of the ``Chat`` displayed in the ``ChatView`` via a share sheet in various formats defined in ``ChatView/ChatExportFormat``.
     ///   - messagePlaceholder: Placeholder text that should be added in the input field.
     public init(
         _ chat: Binding<Chat>,
         disableInput: Binding<Bool> = .constant(false),
+        exportFormat: ChatExportFormat? = nil,
         messagePlaceholder: String? = nil
     ) {
         self._chat = chat
         self._disableInput = disableInput
+        self.exportFormat = exportFormat
         self.messagePlaceholder = messagePlaceholder
     }
 }

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -55,7 +55,7 @@ import SwiftUI
 /// ```
 public struct ChatView: View {
     @Binding var chat: Chat
-    @Binding var disableInput: Bool
+    var disableInput: Bool
     let exportFormat: ChatExportFormat?
     let messagePlaceholder: String?
     
@@ -125,12 +125,12 @@ public struct ChatView: View {
     ///   - messagePlaceholder: Placeholder text that should be added in the input field.
     public init(
         _ chat: Binding<Chat>,
-        disableInput: Binding<Bool> = .constant(false),
+        disableInput: Bool = false,
         exportFormat: ChatExportFormat? = nil,
         messagePlaceholder: String? = nil
     ) {
         self._chat = chat
-        self._disableInput = disableInput
+        self.disableInput = disableInput
         self.exportFormat = exportFormat
         self.messagePlaceholder = messagePlaceholder
     }

--- a/Sources/SpeziChat/MessageInputView.swift
+++ b/Sources/SpeziChat/MessageInputView.swift
@@ -177,7 +177,7 @@ public struct MessageInputView: View {
     @State var chat = [
         ChatEntity(role: .system, content: "System Message!"),
         ChatEntity(role: .system, content: "System Message (hidden)!"),
-        ChatEntity(role: .function, content: "Function Message!"),
+        ChatEntity(role: .function(name: "test_function"), content: "Function Message!"),
         ChatEntity(role: .user, content: "User Message!"),
         ChatEntity(role: .assistant, content: "Assistant Message!")
     ]

--- a/Sources/SpeziChat/MessageStyleViewModifier.swift
+++ b/Sources/SpeziChat/MessageStyleViewModifier.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-
+/// Provides styling for the visualization of a textual ``ChatEntity`` within the ``ChatView``.
 struct MessageStyleModifier: ViewModifier {
     let chatAlignment: ChatEntity.Alignment
 
@@ -41,7 +41,6 @@ struct MessageStyleModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .multilineTextAlignment(multilineTextAlignment)
-            //.frame(maxWidth: .infinity)
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
             .foregroundColor(foregroundColor)
@@ -61,6 +60,24 @@ struct MessageStyleModifier: ViewModifier {
 
 
 extension View {
+    /// Attach this modifier to `Text`-based content in SwiftUI to format it as a typical chat bubble within a chat view.
+    /// The modifier handles text alignment, paddings, colourings, background, as well as the typical chat bubble visualization.
+    ///
+    /// ### Usage
+    ///
+    /// A minimal example can be found below.
+    /// See the ``MessageView`` for a more complete example.
+    ///
+    /// ```swift
+    /// struct ChatMessageView: View {
+    ///     let chatEntity: ChatEntity
+    ///
+    ///     var body: some View {
+    ///         Text(chatEntity.content)
+    ///             .chatMessageStyle(alignment: chatEntity.alignment)
+    ///     }
+    /// }
+    /// ```
     func chatMessageStyle(alignment: ChatEntity.Alignment) -> some View {
         self.modifier(MessageStyleModifier(chatAlignment: alignment))
     }

--- a/Sources/SpeziChat/MessageStyleViewModifier.swift
+++ b/Sources/SpeziChat/MessageStyleViewModifier.swift
@@ -1,0 +1,67 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+struct MessageStyleModifier: ViewModifier {
+    let chatAlignment: ChatEntity.Alignment
+
+    
+    private var foregroundColor: Color {
+        chatAlignment == .leading ? .primary : .white
+    }
+    
+    private var backgroundColor: Color {
+        chatAlignment == .leading ? Color(.secondarySystemBackground) : .accentColor
+    }
+    
+    private var multilineTextAlignment: TextAlignment {
+        chatAlignment == .leading ? .leading : .trailing
+    }
+    
+    private var arrowRotation: Angle {
+        .degrees(chatAlignment == .leading ? -50 : -130)
+    }
+    
+    private var arrowAlignment: CGFloat {
+        chatAlignment == .leading ? -7 : 7
+    }
+    
+    private var overlayAlignment: Alignment {
+        chatAlignment == .leading ? .bottomLeading : .bottomTrailing
+    }
+    
+
+    func body(content: Content) -> some View {
+        content
+            .multilineTextAlignment(multilineTextAlignment)
+            //.frame(maxWidth: .infinity)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .foregroundColor(foregroundColor)
+            .background(backgroundColor)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .overlay(
+                Image(systemName: "arrowtriangle.left.fill")
+                    .accessibilityHidden(true)
+                    .foregroundColor(backgroundColor)
+                    .rotationEffect(arrowRotation)
+                    .offset(x: arrowAlignment),
+                alignment: overlayAlignment
+            )
+            .padding(.horizontal, 4)
+    }
+}
+
+
+extension View {
+    func chatMessageStyle(alignment: ChatEntity.Alignment) -> some View {
+        self.modifier(MessageStyleModifier(chatAlignment: alignment))
+    }
+}

--- a/Sources/SpeziChat/MessageView.swift
+++ b/Sources/SpeziChat/MessageView.swift
@@ -36,27 +36,7 @@ public struct MessageView: View {
     
     private let chat: ChatEntity
     private let hideMessagesWithRoles: Set<ChatEntity.Role>
-
     
-    private var foregroundColor: Color {
-        chat.alignment == .leading ? .primary : .white
-    }
-    
-    private var backgroundColor: Color {
-        chat.alignment == .leading ? Color(.secondarySystemBackground) : .accentColor
-    }
-    
-    private var multilineTextAllignment: TextAlignment {
-        chat.alignment == .leading ? .leading : .trailing
-    }
-    
-    private var arrowRotation: Angle {
-        .degrees(chat.alignment == .leading ? -50 : -130)
-    }
-    
-    private var arrowAllignment: CGFloat {
-        chat.alignment == .leading ? -7 : 7
-    }
     
     public var body: some View {
         if !hideMessagesWithRoles.contains(chat.role) {

--- a/Sources/SpeziChat/MessageView.swift
+++ b/Sources/SpeziChat/MessageView.swift
@@ -30,7 +30,8 @@ public struct MessageView: View {
     /// Contains default values of configurable properties of the ``MessageView``.
     public enum Defaults {
         /// ``ChatEntity`` ``ChatEntity/Role``s that should be hidden by default
-        public static let hideMessagesWithRoles: Set<ChatEntity.Role> = [.system, .function]
+        // Need to state a dummy associated value of the `ChatEntity/Role/function` case
+        public static let hideMessagesWithRoles: Set<ChatEntity.Role> = [.system, .function(name: "")]
     }
     
     
@@ -39,7 +40,8 @@ public struct MessageView: View {
     
     
     public var body: some View {
-        if !hideMessagesWithRoles.contains(chat.role) {
+        // Compare raw value of `ChatEntity/Role`s as associated values present
+        if !hideMessagesWithRoles.contains(where: { $0.rawValue == chat.role.rawValue }) {
             HStack {
                 if chat.alignment == .trailing {
                     Spacer(minLength: 32)
@@ -69,7 +71,7 @@ public struct MessageView: View {
         VStack {
             MessageView(ChatEntity(role: .system, content: "System Message!"), hideMessagesWithRoles: [])
             MessageView(ChatEntity(role: .system, content: "System Message (hidden)!"))
-            MessageView(ChatEntity(role: .function, content: "Function Message!"), hideMessagesWithRoles: [.system])
+            MessageView(ChatEntity(role: .function(name: "test_function"), content: "Function Message!"), hideMessagesWithRoles: [.system])
             MessageView(ChatEntity(role: .user, content: "User Message!"))
             MessageView(ChatEntity(role: .assistant, content: "Assistant Message!"))
         }

--- a/Sources/SpeziChat/MessageView.swift
+++ b/Sources/SpeziChat/MessageView.swift
@@ -30,8 +30,10 @@ public struct MessageView: View {
     /// Contains default values of configurable properties of the ``MessageView``.
     public enum Defaults {
         /// ``ChatEntity`` ``ChatEntity/Role``s that should be hidden by default
-        // Need to state a dummy associated value of the `ChatEntity/Role/function` case
-        public static let hideMessagesWithRoles: Set<ChatEntity.Role> = [.system, .function(name: "")]
+        public static let hideMessagesWithRoles: Set<ChatEntity.Role> = [
+            .system,
+            .function(name: "")     // Need to state a dummy associated value of the `ChatEntity/Role/function` case
+        ]
     }
     
     

--- a/Sources/SpeziChat/MessageView.swift
+++ b/Sources/SpeziChat/MessageView.swift
@@ -65,22 +65,7 @@ public struct MessageView: View {
                     Spacer(minLength: 32)
                 }
                 Text(chat.content)
-                    .multilineTextAlignment(multilineTextAllignment)
-                    .frame(idealWidth: .infinity)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 8)
-                    .foregroundColor(foregroundColor)
-                    .background(backgroundColor)
-                    .clipShape(RoundedRectangle(cornerRadius: 16))
-                    .overlay(
-                        Image(systemName: "arrowtriangle.left.fill")
-                            .accessibilityHidden(true)
-                            .foregroundColor(backgroundColor)
-                            .rotationEffect(arrowRotation)
-                            .offset(x: arrowAllignment),
-                        alignment: chat.alignment == .leading ? .bottomLeading : .bottomTrailing
-                    )
-                    .padding(.horizontal, 4)
+                    .chatMessageStyle(alignment: chat.alignment)
                 if chat.alignment == .leading {
                     Spacer(minLength: 32)
                 }

--- a/Sources/SpeziChat/MessagesView.swift
+++ b/Sources/SpeziChat/MessagesView.swift
@@ -122,7 +122,7 @@ public struct MessagesView: View {
         [
             ChatEntity(role: .system, content: "System Message!"),
             ChatEntity(role: .system, content: "System Message (hidden)!"),
-            ChatEntity(role: .function, content: "Function Message!"),
+            ChatEntity(role: .function(name: "test_function"), content: "Function Message!"),
             ChatEntity(role: .user, content: "User Message!"),
             ChatEntity(role: .assistant, content: "Assistant Message!")
         ]

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -13,11 +13,21 @@ import Foundation
 /// It consists of a ``ChatEntity/Role`` property as well as a `String`-based content property.
 public struct ChatEntity: Codable, Equatable, Hashable {
     /// Indicates which ``ChatEntity/Role`` is associated with a ``ChatEntity``.
-    public enum Role: String, Codable, Equatable {
+    public enum Role: Codable, Equatable, Hashable {
         case system
         case assistant
         case user
-        case function
+        case function(name: String)
+        
+        
+        var rawValue: String {
+            switch self {
+            case .system: "system"
+            case .assistant: "assistant"
+            case .user: "user"
+            case .function: "function"
+            }
+        }
     }
     
     /// Indicates if a ``ChatEntity`` is displayed in a leading or trailing position within a SwiftUI `View`.

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -11,7 +11,7 @@ import Foundation
 
 /// Represents the basic building block of a Spezi ``Chat``.
 /// It consists of a ``ChatEntity/Role`` property as well as a `String`-based content property.
-public struct ChatEntity: Codable, Equatable {
+public struct ChatEntity: Codable, Equatable, Hashable {
     /// Indicates which ``ChatEntity/Role`` is associated with a ``ChatEntity``.
     public enum Role: String, Codable, Equatable {
         case system
@@ -31,6 +31,8 @@ public struct ChatEntity: Codable, Equatable {
     public let role: Role
     /// `String`-based content of the ``ChatEntity``.
     public let content: String
+    /// The creation date of the ``ChatEntity``.
+    public let date: Date
     
     
     /// Dependent on the ``ChatEntity/Role``, display a ``ChatEntity`` in a leading or trailing position.
@@ -51,5 +53,6 @@ public struct ChatEntity: Codable, Equatable {
     public init(role: Role, content: String) {
         self.role = role
         self.content = content
+        self.date = Date()
     }
 }

--- a/Sources/SpeziChat/Resources/Localizable.xcstrings
+++ b/Sources/SpeziChat/Resources/Localizable.xcstrings
@@ -5,7 +5,7 @@
       "localizations" : {
         "en" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@: %2$@"
           }
         }

--- a/Sources/SpeziChat/Resources/Localizable.xcstrings
+++ b/Sources/SpeziChat/Resources/Localizable.xcstrings
@@ -1,6 +1,26 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "%@: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@: %2$@"
+          }
+        }
+      }
+    },
+    "EXPORT_CHAT_BUTTON" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export the Chat"
+          }
+        }
+      }
+    },
     "MESSAGE_INPUT_TEXTFIELD" : {
       "localizations" : {
         "de" : {

--- a/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
+++ b/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
@@ -60,6 +60,7 @@ These entries are mandatory for apps that utilize microphone and speech recognit
 ### Chat View
 
 The ``ChatView`` provides a basic reusable chat view which includes a message input field. The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
+In addition, the ``ChatView`` provides functionality to export the visualized ``Chat`` as a PDF document, JSON representation, or textual UTF-8 file (see ``ChatView/ChatExportFormat``) via a Share Sheet (or Activity View).
 
 ```swift
 struct ChatTestView: View {
@@ -69,7 +70,7 @@ struct ChatTestView: View {
 
     
     var body: some View {
-        ChatView($chat)
+        ChatView($chat, exportFormat: .pdf)
             .navigationTitle("SpeziChat")
     }
 }

--- a/Tests/UITests/TestApp/ChatTestView.swift
+++ b/Tests/UITests/TestApp/ChatTestView.swift
@@ -17,7 +17,7 @@ struct ChatTestView: View {
     
     
     var body: some View {
-        ChatView($chat)
+        ChatView($chat, exportFormat: .text)
             .navigationTitle("SpeziChat")
             .padding(.top, 16)
             .onChange(of: chat) { _, newValue in

--- a/Tests/UITests/TestApp/ChatTestView.swift
+++ b/Tests/UITests/TestApp/ChatTestView.swift
@@ -17,7 +17,7 @@ struct ChatTestView: View {
     
     
     var body: some View {
-        ChatView($chat, exportFormat: .text)
+        ChatView($chat, exportFormat: .pdf)
             .navigationTitle("SpeziChat")
             .padding(.top, 16)
             .onChange(of: chat) { _, newValue in

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -56,7 +56,7 @@ class TestAppUITests: XCTestCase {
         // Store exported chat in Files
         XCTAssert(app.staticTexts["Save to Files"].waitForExistence(timeout: 10))
         app.staticTexts["Save to Files"].tap()
-        sleep(1)
+        sleep(3)
         XCTAssert(app.buttons["Save"].waitForExistence(timeout: 2))
         app.buttons["Save"].tap()
         sleep(3)    // Wait until file is saved
@@ -64,6 +64,7 @@ class TestAppUITests: XCTestCase {
         if app.staticTexts["Replace Existing Items?"].waitForExistence(timeout: 5) {
             XCTAssert(app.buttons["Replace"].waitForExistence(timeout: 2))
             app.buttons["Replace"].tap()
+            sleep(3)    // Wait until file is saved
         }
         
         // Wait until share sheet closed and back on the chat screen

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -59,7 +59,7 @@ class TestAppUITests: XCTestCase {
         sleep(3)
         XCTAssert(app.buttons["Save"].waitForExistence(timeout: 2))
         app.buttons["Save"].tap()
-        sleep(3)    // Wait until file is saved
+        sleep(10)    // Wait until file is saved
         
         if app.staticTexts["Replace Existing Items?"].waitForExistence(timeout: 5) {
             XCTAssert(app.buttons["Replace"].waitForExistence(timeout: 2))

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -18,7 +18,7 @@ class TestAppUITests: XCTestCase {
     }
     
     
-    func testSpeziChat() throws {
+    func testChat() throws {
         let app = XCUIApplication()
         app.launch()
         
@@ -34,5 +34,73 @@ class TestAppUITests: XCTestCase {
         sleep(1)
         
         XCTAssert(app.staticTexts["Assistant Message Response!"].waitForExistence(timeout: 5))
+    }
+    
+    func testChatExport() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        XCTAssert(app.staticTexts["SpeziChat"].waitForExistence(timeout: 1))
+        try app.textViews["Message Input Textfield"].enter(value: "User Message!", dismissKeyboard: false)
+        XCTAssert(app.buttons["Send Message"].waitForExistence(timeout: 5))
+        app.buttons["Send Message"].tap()
+        
+        sleep(1)
+        XCTAssert(app.staticTexts["Assistant Message Response!"].waitForExistence(timeout: 5))
+        
+        XCTAssert(app.buttons["Export the Chat"].waitForExistence(timeout: 2))
+        app.buttons["Export the Chat"].tap()
+        
+        // Share Sheet needs a bit to pop up
+        sleep(2)
+        
+        print(app.staticTexts.debugDescription)
+        
+        XCTAssert(app.staticTexts["Save to Files"].waitForExistence(timeout: 2))
+        app.staticTexts["Save to Files"].tap()
+        
+        XCTAssert(app.buttons["Save"].waitForExistence(timeout: 2))
+        app.buttons["Save"].tap()
+        
+        sleep(1)
+        
+        if app.staticTexts["Replace Existing Items?"].waitForExistence(timeout: 2) {
+            XCTAssert(app.buttons["Replace"].waitForExistence(timeout: 2))
+            app.buttons["Replace"].tap()
+        }
+        
+        // Saving takes unreasonable long sometimes
+        sleep(5)
+        
+        // Go to home screen
+        XCUIDevice.shared.press(.home)
+        
+        // Launch the Files app
+        let filesApp = XCUIApplication(bundleIdentifier: "com.apple.DocumentsApp")
+        filesApp.launch()
+        
+        // Handle already open PDF
+        if filesApp.buttons["Done"].waitForExistence(timeout: 2) {
+            filesApp.buttons["Done"].tap()
+        }
+        
+        // Open File
+        XCTAssert(filesApp.staticTexts["Exported Chat"].waitForExistence(timeout: 2))
+        XCTAssert(filesApp.collectionViews["File View"].waitForExistence(timeout: 2))
+        let files = filesApp.collectionViews["File View"]
+        
+        XCTAssert(files.cells["Exported Chat, pdf"].waitForExistence(timeout: 2))
+        files.cells["Exported Chat, pdf"].images.firstMatch.tap()
+        
+        sleep(3)
+        
+        // Check if PDF contains certain user message
+        let predicate = NSPredicate(format: "label CONTAINS[c] %@", "User Message!")
+        let chatEntry = filesApp.otherElements.containing(predicate).firstMatch
+        XCTAssert(chatEntry.waitForExistence(timeout: 2))
+        
+        // Close File
+        XCTAssert(filesApp.buttons["Done"].waitForExistence(timeout: 2))
+        filesApp.buttons["Done"].tap()
     }
 }

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -62,6 +62,8 @@ class TestAppUITests: XCTestCase {
         XCTAssert(app.buttons["Save"].waitForExistence(timeout: 2))
         app.buttons["Save"].tap()
         
+        sleep(2)
+        
         if app.staticTexts["Replace Existing Items?"].waitForExistence(timeout: 5) {
             XCTAssert(app.buttons["Replace"].waitForExistence(timeout: 2))
             app.buttons["Replace"].tap()

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -62,14 +62,12 @@ class TestAppUITests: XCTestCase {
         XCTAssert(app.buttons["Save"].waitForExistence(timeout: 2))
         app.buttons["Save"].tap()
         
-        sleep(2)
+        sleep(3)
         
         if app.staticTexts["Replace Existing Items?"].waitForExistence(timeout: 5) {
             XCTAssert(app.buttons["Replace"].waitForExistence(timeout: 2))
             app.buttons["Replace"].tap()
         }
-        
-        sleep(2)
         
         // Wait until share sheet closed and back on the chat screen
         XCTAssert(app.staticTexts["SpeziChat"].waitForExistence(timeout: 10))

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -52,17 +52,14 @@ class TestAppUITests: XCTestCase {
         // Export chat via share sheet button
         XCTAssert(app.buttons["Export the Chat"].waitForExistence(timeout: 2))
         app.buttons["Export the Chat"].tap()
-        
-        // Share Sheet needs a bit to pop up
-        sleep(1)
 
         // Store exported chat in Files
         XCTAssert(app.staticTexts["Save to Files"].waitForExistence(timeout: 10))
         app.staticTexts["Save to Files"].tap()
+        sleep(1)
         XCTAssert(app.buttons["Save"].waitForExistence(timeout: 2))
         app.buttons["Save"].tap()
-        
-        sleep(3)
+        sleep(3)    // Wait until file is saved
         
         if app.staticTexts["Replace Existing Items?"].waitForExistence(timeout: 5) {
             XCTAssert(app.buttons["Replace"].waitForExistence(timeout: 2))
@@ -94,8 +91,7 @@ class TestAppUITests: XCTestCase {
         
         // Check if PDF contains certain chat message
         let predicate = NSPredicate(format: "label CONTAINS[c] %@", "User Message!")
-        let chatEntry = filesApp.otherElements.containing(predicate).firstMatch
-        XCTAssert(chatEntry.waitForExistence(timeout: 2))
+        XCTAssert(filesApp.otherElements.containing(predicate).firstMatch.waitForExistence(timeout: 2))
         
         // Close File
         XCTAssert(filesApp.buttons["Done"].waitForExistence(timeout: 2))


### PR DESCRIPTION
# Export of Chat

## :recycle: Current situation & Problem
As of now, SpeziChat doesn't provide any option to export the content of a `ChatView`.


## :gear: Release Notes 
- The `ChatView` now provides functionality to export the `Chat` content as PDF, JSON, or textual UTF-8 file via a Share Sheet (or Activity View).


## :books: Documentation
- Inline docs added, README and DocC Articles updated.


## :white_check_mark: Testing
Manually tested, as UI testing the Share Sheet is complex.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
