### PR TITLE
Lift to SpeziSpeech 1.0, NavigationBar item improvements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "SpeziChat", targets: ["SpeziChat"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziSpeech", .upToNextMinor(from: "0.1.0"))
+        .package(url: "https://github.com/StanfordSpezi/SpeziSpeech", from: "1.0.0")
     ],
     targets: [
         .target(

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -88,16 +88,14 @@ public struct ChatView: View {
             }
         }
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button(action: {
-                    showShareSheet = true
-                }) {
-                    Image(systemName: "square.and.arrow.up")
-                        .accessibilityLabel(Text("EXPORT_CHAT_BUTTON", bundle: .module))
-                        .opacity(exportEnabled ? 1.0 : 0.0)
-                        .scaleEffect(exportEnabled ? 1.0 : 0.8)
-                        .animation(.easeInOut, value: exportEnabled)
-                        .disabled(!exportEnabled)
+            if exportEnabled {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(action: {
+                        showShareSheet = true
+                    }) {
+                        Image(systemName: "square.and.arrow.up")
+                            .accessibilityLabel(Text("EXPORT_CHAT_BUTTON", bundle: .module))
+                    }
                 }
             }
         }
@@ -138,13 +136,18 @@ public struct ChatView: View {
 
 
 #Preview {
-    ChatView(.constant(
-        [
-            ChatEntity(role: .system, content: "System Message!"),
-            ChatEntity(role: .system, content: "System Message (hidden)!"),
-            ChatEntity(role: .user, content: "User Message!"),
-            ChatEntity(role: .assistant, content: "Assistant Message!"),
-            ChatEntity(role: .function(name: "test_function"), content: "Function Message!")
-        ]
-    ))
+    NavigationStack {
+        ChatView(
+            .constant(
+                [
+                    ChatEntity(role: .system, content: "System Message!"),
+                    ChatEntity(role: .system, content: "System Message (hidden)!"),
+                    ChatEntity(role: .user, content: "User Message!"),
+                    ChatEntity(role: .assistant, content: "Assistant Message!"),
+                    ChatEntity(role: .function(name: "test_function"), content: "Function Message!")
+                ]
+            ),
+            exportFormat: .pdf
+        )
+    }
 }


### PR DESCRIPTION
# Lift to SpeziSpeech 1.0, NavigationBar item improvements

## :recycle: Current situation & Problem
`SpeziChat` is still dependent on an old tagged version of `SpeziSpeech`.
In addition, the navigation bar share icon always allocates space (even when the icon is not shown - initially done for animation purposes), leading to issues with `View`s reusing the `ChatView` while adding navigation bar items.


## :gear: Release Notes 
- Lift `SpeziChat` to tagged 1.0.0 version of `SpeziSpeech`.
- Adjust navigation bar item behaviour of export button


## :books: Documentation
--


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
