### PR TITLE
Make UI tests of Export functionality more stable

### DIFF
--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -40,7 +40,7 @@ class TestAppUITests: XCTestCase {
         let app = XCUIApplication()
         let filesApp = XCUIApplication(bundleIdentifier: "com.apple.DocumentsApp")
         
-        while(true) {
+        while true {
             app.launch()
             
             // Entering dummy chat value

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -39,8 +39,9 @@ class TestAppUITests: XCTestCase {
     func testChatExport() throws {
         let app = XCUIApplication()
         let filesApp = XCUIApplication(bundleIdentifier: "com.apple.DocumentsApp")
+        let maxRetries = 10
         
-        while true {
+        for _ in 0...maxRetries {
             app.launch()
             
             // Entering dummy chat value

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -38,47 +38,56 @@ class TestAppUITests: XCTestCase {
     
     func testChatExport() throws {
         let app = XCUIApplication()
-        app.launch()
-        
-        // Entering dummy chat value
-        XCTAssert(app.staticTexts["SpeziChat"].waitForExistence(timeout: 1))
-        try app.textViews["Message Input Textfield"].enter(value: "User Message!", dismissKeyboard: false)
-        XCTAssert(app.buttons["Send Message"].waitForExistence(timeout: 5))
-        app.buttons["Send Message"].tap()
-        
-        sleep(1)
-        XCTAssert(app.staticTexts["Assistant Message Response!"].waitForExistence(timeout: 5))
-        
-        // Export chat via share sheet button
-        XCTAssert(app.buttons["Export the Chat"].waitForExistence(timeout: 2))
-        app.buttons["Export the Chat"].tap()
-
-        // Store exported chat in Files
-        XCTAssert(app.staticTexts["Save to Files"].waitForExistence(timeout: 10))
-        app.staticTexts["Save to Files"].tap()
-        sleep(3)
-        XCTAssert(app.buttons["Save"].waitForExistence(timeout: 2))
-        app.buttons["Save"].tap()
-        sleep(10)    // Wait until file is saved
-        
-        if app.staticTexts["Replace Existing Items?"].waitForExistence(timeout: 5) {
-            XCTAssert(app.buttons["Replace"].waitForExistence(timeout: 2))
-            app.buttons["Replace"].tap()
-            sleep(3)    // Wait until file is saved
-        }
-        
-        // Wait until share sheet closed and back on the chat screen
-        XCTAssert(app.staticTexts["SpeziChat"].waitForExistence(timeout: 10))
-        
-        XCUIDevice.shared.press(.home)
-        
-        // Launch the Files app
         let filesApp = XCUIApplication(bundleIdentifier: "com.apple.DocumentsApp")
-        filesApp.launch()
         
-        // Handle already open files
-        if filesApp.buttons["Done"].waitForExistence(timeout: 2) {
-            filesApp.buttons["Done"].tap()
+        while(true) {
+            app.launch()
+            
+            // Entering dummy chat value
+            XCTAssert(app.staticTexts["SpeziChat"].waitForExistence(timeout: 1))
+            try app.textViews["Message Input Textfield"].enter(value: "User Message!", dismissKeyboard: false)
+            XCTAssert(app.buttons["Send Message"].waitForExistence(timeout: 5))
+            app.buttons["Send Message"].tap()
+            
+            sleep(1)
+            XCTAssert(app.staticTexts["Assistant Message Response!"].waitForExistence(timeout: 5))
+            
+            // Export chat via share sheet button
+            XCTAssert(app.buttons["Export the Chat"].waitForExistence(timeout: 2))
+            app.buttons["Export the Chat"].tap()
+            
+            // Store exported chat in Files
+            XCTAssert(app.staticTexts["Save to Files"].waitForExistence(timeout: 10))
+            app.staticTexts["Save to Files"].tap()
+            sleep(3)
+            XCTAssert(app.buttons["Save"].waitForExistence(timeout: 2))
+            app.buttons["Save"].tap()
+            sleep(10)    // Wait until file is saved
+            
+            if app.staticTexts["Replace Existing Items?"].waitForExistence(timeout: 5) {
+                XCTAssert(app.buttons["Replace"].waitForExistence(timeout: 2))
+                app.buttons["Replace"].tap()
+                sleep(3)    // Wait until file is saved
+            }
+            
+            // Wait until share sheet closed and back on the chat screen
+            XCTAssert(app.staticTexts["SpeziChat"].waitForExistence(timeout: 10))
+            
+            XCUIDevice.shared.press(.home)
+            
+            // Launch the Files app
+            filesApp.launch()
+            
+            // Handle already open files
+            if filesApp.buttons["Done"].waitForExistence(timeout: 2) {
+                filesApp.buttons["Done"].tap()
+            }
+            
+            // Check if file exists - If not, try the export procedure again
+            // Saving to files is very flakey on the runners, needs multiple attempts to succeed
+            if filesApp.staticTexts["Exported Chat"].waitForExistence(timeout: 2) {
+                break
+            }
         }
         
         // Open File


### PR DESCRIPTION
# Make UI tests of Export functionality more stable

## :recycle: Current situation & Problem
As of now, the UI tests of the export functionality are quite flakey on the runners. For some reason, the file saving to the Files app via the iOS Share sheet is very flakey on the runners.


## :gear: Release Notes 
- Make UI tests of Export functionality more stable


## :books: Documentation
Added proper documentation for the reasoning of the changes


## :white_check_mark: Testing
Adjusted the UI tests, manual testing


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
