### PR TITLE
Show export button only for visible chat messages

### DIFF
--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -112,7 +112,9 @@ public struct ChatView: View {
     }
     
     private var exportEnabled: Bool {
-        exportFormat != nil && !chat.isEmpty
+        exportFormat != nil && chat.contains(where: {
+            $0.role == .assistant || $0.role == .user   // Only show export toolbar item if there are visible messages
+        })
     }
     
     

--- a/Sources/SpeziChat/Models/ChatEntity+Alignment.swift
+++ b/Sources/SpeziChat/Models/ChatEntity+Alignment.swift
@@ -1,0 +1,29 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+extension ChatEntity {
+    /// Indicates if a ``ChatEntity`` is displayed in a leading or trailing position within a SwiftUI `View`.
+    enum Alignment {
+        case leading
+        case trailing
+    }
+    
+    
+    /// Dependent on the ``ChatEntity/Role``, display a ``ChatEntity`` in a leading or trailing position.
+    var alignment: Alignment {
+        switch self.role {
+        case .user, .function:
+            return .trailing
+        default:
+            return .leading
+        }
+    }
+}

--- a/Sources/SpeziChat/Models/ChatEntity+Alignment.swift
+++ b/Sources/SpeziChat/Models/ChatEntity+Alignment.swift
@@ -20,7 +20,7 @@ extension ChatEntity {
     /// Dependent on the ``ChatEntity/Role``, display a ``ChatEntity`` in a leading or trailing position.
     var alignment: Alignment {
         switch self.role {
-        case .user, .function:
+        case .user:
             return .trailing
         default:
             return .leading

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -30,12 +30,6 @@ public struct ChatEntity: Codable, Equatable, Hashable {
         }
     }
     
-    /// Indicates if a ``ChatEntity`` is displayed in a leading or trailing position within a SwiftUI `View`.
-    enum Alignment {
-        case leading
-        case trailing
-    }
-    
     
     /// ``ChatEntity/Role`` associated with the ``ChatEntity``.
     public let role: Role
@@ -43,17 +37,6 @@ public struct ChatEntity: Codable, Equatable, Hashable {
     public let content: String
     /// The creation date of the ``ChatEntity``.
     public let date: Date
-    
-    
-    /// Dependent on the ``ChatEntity/Role``, display a ``ChatEntity`` in a leading or trailing position.
-    var alignment: Alignment {
-        switch self.role {
-        case .user:
-            return .trailing
-        default:
-            return .leading
-        }
-    }
     
     
     /// Creates a ``ChatEntity`` which is the building block of a Spezi ``Chat``.


### PR DESCRIPTION
# Show export button only for visible chat messages

## :recycle: Current situation & Problem
As of now, we show the export button within the `ChatView` toolbar if the export is configured by the user AND the chat is not empty. However, this is a bit short-sighted as for e.g., `SpeziLLM` the export button should not be showcased if there are only (invisible) system message or function calling messages within the chat.


## :gear: Release Notes 
- Show export button only in case there are visible chat messages (assistant and user messages)


## :books: Documentation
Proper documentation


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
