### PR TITLE
`AttributedString` content in `ChatEntity`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ These entries are mandatory for apps that utilize microphone and speech recognit
 ## Usage
 
 The underlying data model of [SpeziChat](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat) is a [`Chat`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chat). It represents the content of a typical text-based chat between user and system(s). A `Chat` is nothing more than an ordered array of [`ChatEntity`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity)s which contain the content of the individual messages.
-A `ChatEntity` consists of a [`ChatEntity/Role`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity/role-swift.enum), a timestamp as well as an `AttributedString`-based content, providing traits like visual styles for display (e.g., Markdown), accessibility for guided access, and hyperlink data for linking between data sources.
+A `ChatEntity` consists of a [`ChatEntity/Role`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity/role-swift.enum), a timestamp as well as an `String`-based content which can contain Markdown-formatted text.
+
+> [!NOTE]  
+> The [`ChatEntity`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity) is able to store Markdown-based content which in turn is rendered as styled text in the `ChatView`, `MessagesView`, and `MessageView`.
 
 ### Chat View
 
@@ -75,9 +78,6 @@ struct ChatTestView: View {
     }
 }
 ```
-
-> [!NOTE]  
-> The [`ChatEntity`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity) is able to store Markdown-based content which in turn is rendered as styled text in the `ChatView`, `MessagesView`, and `MessageView`.
 
 ### Messages View
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,15 @@ As [SpeziChat](https://swiftpackageindex.com/stanfordspezi/spezichat/documentati
 
 These entries are mandatory for apps that utilize microphone and speech recognition features. Failing to provide them will result in your app being unable to access these features. 
    
-## Examples
+## Usage
+
+The underlying data model of [SpeziChat](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat) is a [`Chat`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chat). It represents the content of a typical text-based chat between user and system(s). A `Chat` is nothing more than an ordered array of [`ChatEntity`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity)s which contain the content of the individual messages.
+A `ChatEntity` consists of a [`ChatEntity/Role`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity/role-swift.enum), a timestamp as well as an `AttributedString`-based content, providing traits like visual styles for display (e.g., Markdown), accessibility for guided access, and hyperlink data for linking between data sources.
 
 ### Chat View
 
 The [`ChatView`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatview) provides a basic reusable chat view which includes a message input field. The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text. It accepts an additional `messagePendingAnimation` parameter to control whether a chat bubble animation is shown for a message that is currently being composed. By default, `messagePendingAnimation` has a value of `nil` and does not show.
-In addition, the [`ChatView`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatview) provides functionality to export the visualized [`Chat`](https://swiftpackageindex.com/stanfordspezi/spezichat/0.1.1/documentation/spezichat/chat) as a PDF document, JSON representation, or textual UTF-8 file (see `ChatView/ChatExportFormat`) via a Share Sheet (or Activity View).
+In addition, the [`ChatView`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatview) provides functionality to export the visualized [`Chat`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chat) as a PDF document, JSON representation, or textual UTF-8 file (see `ChatView/ChatExportFormat`) via a Share Sheet (or Activity View).
 
 ```swift
 struct ChatTestView: View {

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ struct ChatTestView: View {
 }
 ```
 
+> [!NOTE]  
+> The [`ChatEntity`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity) is able to store Markdown-based content which in turn is rendered as styled text in the `ChatView`, `MessagesView`, and `MessageView`.
+
 ### Messages View
 
 The [`MessagesView`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/messagesview) displays a `Chat` containing multiple `ChatEntity`s with different `ChatEntity/Role`s in a typical chat-like fashion.

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -84,7 +84,7 @@ public struct ChatView: View {
                 MessageInputView($chat, messagePlaceholder: messagePlaceholder)
                     .disabled(disableInput)
                     .onPreferenceChange(MessageInputViewHeightKey.self) { newValue in
-                        messageInputHeight = newValue + 16
+                        messageInputHeight = newValue + 12
                     }
             }
         }

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -84,7 +84,7 @@ public struct ChatView: View {
                 MessageInputView($chat, messagePlaceholder: messagePlaceholder)
                     .disabled(disableInput)
                     .onPreferenceChange(MessageInputViewHeightKey.self) { newValue in
-                        messageInputHeight = newValue
+                        messageInputHeight = newValue + 8
                     }
             }
         }

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -84,7 +84,7 @@ public struct ChatView: View {
                 MessageInputView($chat, messagePlaceholder: messagePlaceholder)
                     .disabled(disableInput)
                     .onPreferenceChange(MessageInputViewHeightKey.self) { newValue in
-                        messageInputHeight = newValue //+ 12
+                        messageInputHeight = newValue + 12
                     }
             }
         }

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -84,7 +84,7 @@ public struct ChatView: View {
                 MessageInputView($chat, messagePlaceholder: messagePlaceholder)
                     .disabled(disableInput)
                     .onPreferenceChange(MessageInputViewHeightKey.self) { newValue in
-                        messageInputHeight = newValue + 8
+                        messageInputHeight = newValue + 16
                     }
             }
         }

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -84,7 +84,7 @@ public struct ChatView: View {
                 MessageInputView($chat, messagePlaceholder: messagePlaceholder)
                     .disabled(disableInput)
                     .onPreferenceChange(MessageInputViewHeightKey.self) { newValue in
-                        messageInputHeight = newValue + 12
+                        messageInputHeight = newValue //+ 12
                     }
             }
         }

--- a/Sources/SpeziChat/MessageStyleViewModifier.swift
+++ b/Sources/SpeziChat/MessageStyleViewModifier.swift
@@ -21,10 +21,6 @@ struct MessageStyleModifier: ViewModifier {
         chatAlignment == .leading ? Color(.secondarySystemBackground) : .accentColor
     }
     
-    private var multilineTextAlignment: TextAlignment {
-        chatAlignment == .leading ? .leading : .trailing
-    }
-    
     private var arrowRotation: Angle {
         .degrees(chatAlignment == .leading ? -50 : -130)
     }
@@ -40,7 +36,6 @@ struct MessageStyleModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .multilineTextAlignment(multilineTextAlignment)
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
             .foregroundColor(foregroundColor)

--- a/Sources/SpeziChat/MessageView.swift
+++ b/Sources/SpeziChat/MessageView.swift
@@ -48,7 +48,7 @@ public struct MessageView: View {
                 if chat.alignment == .trailing {
                     Spacer(minLength: 32)
                 }
-                Text(chat.content)
+                Text(chat.attributedContent)
                     .chatMessageStyle(alignment: chat.alignment)
                 if chat.alignment == .leading {
                     Spacer(minLength: 32)

--- a/Sources/SpeziChat/MessageView.swift
+++ b/Sources/SpeziChat/MessageView.swift
@@ -76,7 +76,9 @@ public struct MessageView: View {
             MessageView(ChatEntity(role: .function(name: "test_function"), content: "Function Message!"), hideMessagesWithRoles: [.system])
             MessageView(ChatEntity(role: .user, content: "User Message!"))
             MessageView(ChatEntity(role: .assistant, content: "Assistant Message!"))
+            MessageView(ChatEntity(role: .user, content: "Long User Message that spans over two lines!"))
+            MessageView(ChatEntity(role: .assistant, content: "Long Assistant Message that spans over two lines!"))
         }
-        .padding()
+            .padding()
     }
 }

--- a/Sources/SpeziChat/Models/Chat.swift
+++ b/Sources/SpeziChat/Models/Chat.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-/// Represents all necessary content of a typical text-based chat between the user and system(s).
-/// Consists of an ordered array of ``ChatEntity``s
+/// Represents the content of a typical text-based chat between user and system(s).
+///
+/// A ``Chat`` is nothing more than an ordered array of ``ChatEntity``s which contain the content of the individual messages.
 public typealias Chat = [ChatEntity]

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -12,7 +12,9 @@ import Foundation
 /// Represents the basic building block of a Spezi ``Chat``.
 ///
 /// A ``ChatEntity`` can be thought of as a single message entity within a ``Chat``
-/// It consists of a ``ChatEntity/Role``, a timestamp in the form of a `Date` as well as an `AttributedString`-based content property, enabling the persistence of Markdown content.
+/// It consists of a ``ChatEntity/Role``, a timestamp in the form of a `Date` as well as an `AttributedString`-based content property,
+/// providing traits like visual styles for display (e.g., Markdown), accessibility for guided access, and hyperlink data for linking between data sources.
+
 public struct ChatEntity: Codable, Equatable, Hashable {
     /// Indicates which ``ChatEntity/Role`` is associated with a ``ChatEntity``.
     public enum Role: Codable, Equatable, Hashable {

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -12,9 +12,7 @@ import Foundation
 /// Represents the basic building block of a Spezi ``Chat``.
 ///
 /// A ``ChatEntity`` can be thought of as a single message entity within a ``Chat``
-/// It consists of a ``ChatEntity/Role``, a timestamp in the form of a `Date` as well as an `AttributedString`-based content property,
-/// providing traits like visual styles for display (e.g., Markdown), accessibility for guided access, and hyperlink data for linking between data sources.
-
+/// It consists of a ``ChatEntity/Role``, a timestamp in the form of a `Date` as well as an `String`-based ``ChatEntity/content`` property which can contain Markdown-formatted text.
 public struct ChatEntity: Codable, Equatable, Hashable {
     /// Indicates which ``ChatEntity/Role`` is associated with a ``ChatEntity``.
     public enum Role: Codable, Equatable, Hashable {
@@ -37,29 +35,35 @@ public struct ChatEntity: Codable, Equatable, Hashable {
     
     /// ``ChatEntity/Role`` associated with the ``ChatEntity``.
     public let role: Role
-    /// `AttributedString`-based content of the ``ChatEntity``.
-    public let content: AttributedString
+    /// `String`-based content of the ``ChatEntity``.
+    public let content: String
     /// The creation date of the ``ChatEntity``.
     public let date: Date
-    
+
     
     /// Creates a ``ChatEntity`` which is the building block of a Spezi ``Chat``.
+    ///
     /// - Parameters:
     ///    - role: ``ChatEntity/Role`` associated with the ``ChatEntity``.
-    ///    - content: `AttributedString`-based content of the ``ChatEntity``, enabling the persistence of Markdown content.
-    public init(role: Role, content: AttributedString) {
+    ///    - content: `String`-based content of the ``ChatEntity``. Can contain Markdown-formatted text.
+    public init<Content: StringProtocol>(role: Role, content: Content) {
         self.role = role
-        self.content = content
+        self.content = String(content)
         self.date = Date()
     }
     
-    /// Creates a ``ChatEntity`` which is the building block of a Spezi ``Chat``.
-    /// - Parameters:
-    ///    - role: ``ChatEntity/Role`` associated with the ``ChatEntity``.
-    ///    - content: `String`-based content of the ``ChatEntity``, stored as a `String` literal.
-    public init<Content: StringProtocol>(role: Role, content: Content) {
-        self.role = role
-        self.content = AttributedString(stringLiteral: String(content))
-        self.date = Date()
+    
+    /// Markdown-formatted ``ChatEntity/content`` as `AttributedString`.
+    public var attributedContent: AttributedString {
+        let markdownOptions = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace,
+            failurePolicy: .returnPartiallyParsedIfPossible
+        )
+        
+        if let attributedContent = try? AttributedString(markdown: content, options: markdownOptions) {
+            return attributedContent
+        } else {
+            return AttributedString(stringLiteral: content)
+        }
     }
 }

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -39,21 +39,9 @@ public struct ChatEntity: Codable, Equatable, Hashable {
     public let content: String
     /// The creation date of the ``ChatEntity``.
     public let date: Date
-
-    
-    /// Creates a ``ChatEntity`` which is the building block of a Spezi ``Chat``.
-    ///
-    /// - Parameters:
-    ///    - role: ``ChatEntity/Role`` associated with the ``ChatEntity``.
-    ///    - content: `String`-based content of the ``ChatEntity``. Can contain Markdown-formatted text.
-    public init<Content: StringProtocol>(role: Role, content: Content) {
-        self.role = role
-        self.content = String(content)
-        self.date = Date()
-    }
     
     
-    /// Markdown-formatted ``ChatEntity/content`` as `AttributedString`.
+    /// Markdown-formatted ``ChatEntity/content`` as an `AttributedString`, required to render the text in Markdown-style within the ``MessageView``.
     public var attributedContent: AttributedString {
         let markdownOptions = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .inlineOnlyPreservingWhitespace,
@@ -65,5 +53,17 @@ public struct ChatEntity: Codable, Equatable, Hashable {
         } else {
             return AttributedString(stringLiteral: content)
         }
+    }
+
+    
+    /// Creates a ``ChatEntity`` which is the building block of a Spezi ``Chat``.
+    ///
+    /// - Parameters:
+    ///    - role: ``ChatEntity/Role`` associated with the ``ChatEntity``.
+    ///    - content: `String`-based content of the ``ChatEntity``. Can contain Markdown-formatted text.
+    public init<Content: StringProtocol>(role: Role, content: Content) {
+        self.role = role
+        self.content = String(content)
+        self.date = Date()
     }
 }

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -42,7 +42,7 @@ public struct ChatEntity: Codable, Equatable, Hashable {
     
     
     /// Markdown-formatted ``ChatEntity/content`` as an `AttributedString`, required to render the text in Markdown-style within the ``MessageView``.
-    public var attributedContent: AttributedString {
+    var attributedContent: AttributedString {
         let markdownOptions = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .inlineOnlyPreservingWhitespace,
             failurePolicy: .returnPartiallyParsedIfPossible

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -10,7 +10,9 @@ import Foundation
 
 
 /// Represents the basic building block of a Spezi ``Chat``.
-/// It consists of a ``ChatEntity/Role`` property as well as a `String`-based content property.
+///
+/// A ``ChatEntity`` can be thought of as a single message entity within a ``Chat``
+/// It consists of a ``ChatEntity/Role``, a timestamp in the form of a `Date` as well as an `AttributedString`-based content property, enabling the persistence of Markdown content.
 public struct ChatEntity: Codable, Equatable, Hashable {
     /// Indicates which ``ChatEntity/Role`` is associated with a ``ChatEntity``.
     public enum Role: Codable, Equatable, Hashable {
@@ -33,8 +35,8 @@ public struct ChatEntity: Codable, Equatable, Hashable {
     
     /// ``ChatEntity/Role`` associated with the ``ChatEntity``.
     public let role: Role
-    /// `String`-based content of the ``ChatEntity``.
-    public let content: String
+    /// `AttributedString`-based content of the ``ChatEntity``.
+    public let content: AttributedString
     /// The creation date of the ``ChatEntity``.
     public let date: Date
     
@@ -42,10 +44,20 @@ public struct ChatEntity: Codable, Equatable, Hashable {
     /// Creates a ``ChatEntity`` which is the building block of a Spezi ``Chat``.
     /// - Parameters:
     ///    - role: ``ChatEntity/Role`` associated with the ``ChatEntity``.
-    ///    - content: `String`-based content of the ``ChatEntity``.
-    public init(role: Role, content: String) {
+    ///    - content: `AttributedString`-based content of the ``ChatEntity``, enabling the persistence of Markdown content.
+    public init(role: Role, content: AttributedString) {
         self.role = role
         self.content = content
+        self.date = Date()
+    }
+    
+    /// Creates a ``ChatEntity`` which is the building block of a Spezi ``Chat``.
+    /// - Parameters:
+    ///    - role: ``ChatEntity/Role`` associated with the ``ChatEntity``.
+    ///    - content: `String`-based content of the ``ChatEntity``, stored as a `String` literal.
+    public init<Content: StringProtocol>(role: Role, content: Content) {
+        self.role = role
+        self.content = AttributedString(stringLiteral: String(content))
         self.date = Date()
     }
 }

--- a/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
+++ b/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
@@ -58,7 +58,9 @@ These entries are mandatory for apps that utilize microphone and speech recognit
 ## Usage
 
 The underlying data model of ``SpeziChat`` is a ``Chat``. It represents the content of a typical text-based chat between user and system(s). A ``Chat`` is nothing more than an ordered array of ``ChatEntity``s which contain the content of the individual messages.
-A ``ChatEntity`` consists of a ``ChatEntity/Role-swift.enum``, a timestamp as well as an `AttributedString`-based content, providing traits like visual styles for display (e.g., Markdown), accessibility for guided access, and hyperlink data for linking between data sources.
+A ``ChatEntity`` consists of a ``ChatEntity/Role-swift.enum``, a timestamp as well as an `String`-based content which can contain Markdown-formatted text.
+
+> Tip: The ``ChatEntity`` is able to store Markdown-based content which in turn is rendered as styled text in the ``ChatView``, ``MessagesView``, and ``MessageView``.
 
 ### Chat View
 
@@ -78,8 +80,6 @@ struct ChatTestView: View {
     }
 }
 ```
-
-> Tip: The ``ChatEntity`` is able to store Markdown-based content which in turn is rendered as styled text in the ``ChatView``, ``MessagesView``, and ``MessageView``.
 
 ### Messages View
 

--- a/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
+++ b/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
@@ -55,7 +55,10 @@ As ``SpeziChat`` is utilizing the [SpeziSpeech](https://github.com/StanfordSpezi
 
 These entries are mandatory for apps that utilize microphone and speech recognition features. Failing to provide them will result in your app being unable to access these features. 
 
-## Examples
+## Usage
+
+The underlying data model of ``SpeziChat`` is a ``Chat``. It represents the content of a typical text-based chat between user and system(s). A ``Chat`` is nothing more than an ordered array of ``ChatEntity``s which contain the content of the individual messages.
+A ``ChatEntity`` consists of a ``ChatEntity/Role-swift.enum``, a timestamp as well as an `AttributedString`-based content, providing traits like visual styles for display (e.g., Markdown), accessibility for guided access, and hyperlink data for linking between data sources.
 
 ### Chat View
 
@@ -75,6 +78,8 @@ struct ChatTestView: View {
     }
 }
 ```
+
+> Tip: The ``ChatEntity`` is able to store Markdown-based content which in turn is rendered as styled text in the ``ChatView``, ``MessagesView``, and ``MessageView``.
 
 ### Messages View
 

--- a/Tests/UITests/TestApp/ChatTestView.swift
+++ b/Tests/UITests/TestApp/ChatTestView.swift
@@ -11,8 +11,27 @@ import SwiftUI
 
 
 struct ChatTestView: View {
+    enum Defaults {
+        static let initialMessage: AttributedString = {
+            guard let attributedString = try? AttributedString(markdown: "**Assistant** Message!") else {
+                preconditionFailure("Mock Chat Content is not parsable as an AttributedString.")
+            }
+            
+            return attributedString
+        }()
+        
+        static let responseMessage: AttributedString = {
+            guard let attributedString = try? AttributedString(markdown: "**Assistant** Message Response!") else {
+                preconditionFailure("Mock Chat Content is not parsable as an AttributedString.")
+            }
+            
+            return attributedString
+        }()
+    }
+    
+    
     @State private var chat: Chat = [
-        ChatEntity(role: .assistant, content: "Assistant Message!")
+        ChatEntity(role: .assistant, content: Defaults.initialMessage)
     ]
     
     
@@ -27,7 +46,7 @@ struct ChatTestView: View {
                         try await Task.sleep(for: .seconds(5))
                         
                         await MainActor.run {
-                            chat.append(.init(role: .assistant, content: "Assistant Message Response!"))
+                            chat.append(.init(role: .assistant, content: Defaults.responseMessage))
                         }
                     }
                 }

--- a/Tests/UITests/TestApp/ChatTestView.swift
+++ b/Tests/UITests/TestApp/ChatTestView.swift
@@ -11,27 +11,8 @@ import SwiftUI
 
 
 struct ChatTestView: View {
-    enum Defaults {
-        static let initialMessage: AttributedString = {
-            guard let attributedString = try? AttributedString(markdown: "**Assistant** Message!") else {
-                preconditionFailure("Mock Chat Content is not parsable as an AttributedString.")
-            }
-            
-            return attributedString
-        }()
-        
-        static let responseMessage: AttributedString = {
-            guard let attributedString = try? AttributedString(markdown: "**Assistant** Message Response!") else {
-                preconditionFailure("Mock Chat Content is not parsable as an AttributedString.")
-            }
-            
-            return attributedString
-        }()
-    }
-    
-    
     @State private var chat: Chat = [
-        ChatEntity(role: .assistant, content: Defaults.initialMessage)
+        ChatEntity(role: .assistant, content: "**Assistant** Message!")
     ]
     
     
@@ -46,7 +27,7 @@ struct ChatTestView: View {
                         try await Task.sleep(for: .seconds(5))
                         
                         await MainActor.run {
-                            chat.append(.init(role: .assistant, content: Defaults.responseMessage))
+                            chat.append(.init(role: .assistant, content: "**Assistant** Message Response!"))
                         }
                     }
                 }


### PR DESCRIPTION
# `AttributedString` content in `ChatEntity`

## :recycle: Current situation & Problem
At the moment, SpeziChat is not able to store and display Markdown-based content, which is typically returned from LLM providers like OpenAI.


## :gear: Release Notes 
- The content property of the `ChatEntity` can now be accessed as a computed property that is an `AttributedString`, providing the ability to render Markdown-formatted text in the `MessageView`.


## :books: Documentation
In-line DocC comments written and adjusted


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
