### PR TITLE
Text-to-speech capabilities

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,8 @@ let package = Package(
         .target(
             name: "SpeziChat",
             dependencies: [
-                .product(name: "SpeziSpeechRecognizer", package: "SpeziSpeech")
+                .product(name: "SpeziSpeechRecognizer", package: "SpeziSpeech"),
+                .product(name: "SpeziSpeechSynthesizer", package: "SpeziSpeech")
             ]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ These entries are mandatory for apps that utilize microphone and speech recognit
 ## Usage
 
 The underlying data model of [SpeziChat](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat) is a [`Chat`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chat). It represents the content of a typical text-based chat between user and system(s). A `Chat` is nothing more than an ordered array of [`ChatEntity`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity)s which contain the content of the individual messages.
-A `ChatEntity` consists of a [`ChatEntity/Role`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity/role-swift.enum), a timestamp as well as an `String`-based content which can contain Markdown-formatted text.
+A `ChatEntity` consists of a [`ChatEntity/Role`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity/role-swift.enum), a timestamp as well as an `String`-based content which can contain Markdown-formatted text. In addition, a flag indicates if the `ChatEntity` is complete and no further content will be added.
 
 > [!NOTE]  
 > The [`ChatEntity`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity) is able to store Markdown-based content which in turn is rendered as styled text in the `ChatView`, `MessagesView`, and `MessageView`.
@@ -78,6 +78,9 @@ struct ChatTestView: View {
     }
 }
 ```
+
+> [!NOTE]
+> The `ChatView` provides speech-to-text (recognition) as well as text-to-speech (synthesize) accessibility capabilities out-of-the-box via the [`SpeziSpeech`](https://github.com/StanfordSpezi/SpeziSpeech) module, facilitating seamless interaction with the content of the `ChatView`.
 
 ### Messages View
 

--- a/Sources/SpeziChat/ChatView+SpeechButton.swift
+++ b/Sources/SpeziChat/ChatView+SpeechButton.swift
@@ -11,27 +11,24 @@ import SwiftUI
 
 /// The underlying `ViewModifier` of `View/speechToolbarButton(enabled:muted:)`.
 private struct ChatViewSpeechButtonModifier: ViewModifier {
-    let enabled: Bool
     @Binding var muted: Bool
     
     
     func body(content: Content) -> some View {
         content
             .toolbar {
-                if enabled {
-                    ToolbarItem(placement: .primaryAction) {
-                        Button(action: {
-                            muted.toggle()
-                        }) {
-                            if !muted {
-                                Image(systemName: "speaker")
-                                    .accessibilityIdentifier("Speaker")
-                                    .accessibilityLabel(Text("Text to speech is enabled, press to disable text to speech.", bundle: .module))
-                            } else {
-                                Image(systemName: "speaker.slash")
-                                    .accessibilityIdentifier("Speaker strikethrough")
-                                    .accessibilityLabel(Text("Text to speech is disabled, press to enable text to speech.", bundle: .module))
-                            }
+                ToolbarItem(placement: .primaryAction) {
+                    Button(action: {
+                        muted.toggle()
+                    }) {
+                        if !muted {
+                            Image(systemName: "speaker")
+                                .accessibilityIdentifier("Speaker")
+                                .accessibilityLabel(Text("Text to speech is enabled, press to disable text to speech.", bundle: .module))
+                        } else {
+                            Image(systemName: "speaker.slash")
+                                .accessibilityIdentifier("Speaker strikethrough")
+                                .accessibilityLabel(Text("Text to speech is disabled, press to enable text to speech.", bundle: .module))
                         }
                     }
                 }
@@ -72,13 +69,14 @@ extension View {
     ///     }
     /// }
     /// ```
-    public func speechToolbarButton(    // swiftlint:disable:this function_default_parameter_at_end
-        enabled: Bool = true,
+    ///
+    /// - Parameters:
+    ///    - muted: A SwiftUI `Binding` that indicates if the speech output is currently muted. The `Binding` enables the adjustment of the muted status by both the caller and the toolbar `Button`.
+    public func speechToolbarButton(
         muted: Binding<Bool>
     ) -> some View {
         modifier(
             ChatViewSpeechButtonModifier(
-                enabled: enabled,
                 muted: muted
             )
         )

--- a/Sources/SpeziChat/ChatView+SpeechButton.swift
+++ b/Sources/SpeziChat/ChatView+SpeechButton.swift
@@ -48,6 +48,8 @@ extension View {
     /// The outside `View` is able to observe taps on that `Button` via passing in a SwiftUI `Binding` as the `muted` parameter, directly tracking the state of the `Button` but also being able to modify it from the outside.
     /// In addition, the button can be programatically hidden by adjusting the `enabled` parameter at any time.
     ///
+    /// - Warning: Ensure that the ``ChatView`` resides within a SwiftUI `NavigationStack`, otherwise the added toolbar `Button` won't be shown.
+    ///
     /// ### Usage
     ///
     /// The code snipped below demonstrates a minimal example of adding a text-to-speech toolbar button that mutes or unmutes text-to-speech output generation.

--- a/Sources/SpeziChat/ChatView+SpeechButton.swift
+++ b/Sources/SpeziChat/ChatView+SpeechButton.swift
@@ -41,7 +41,7 @@ struct ChatViewSpeechButtonModifier: ViewModifier {
 
 
 extension View {
-    /// Adds a toolbar `Button` to enable or disable text-to-speech capabilities.
+    /// Adds a toolbar `Button` to mute or unmute text-to-speech capabilities.
     ///
     /// When attaching the ``speechToolbarButton(enabled:muted:)`` modifier to a `View` that resides within a SwiftUI `NavigationStack`,
     /// a `Button` is added to the toolbar that enables text-to-speech capabilities.
@@ -59,10 +59,9 @@ extension View {
     ///     ]
     ///     @State private var muted = true
     ///
-    ///
     ///     var body: some View {
     ///         ChatView($chat)
-    ///             .speakChat(chat, muted: muted)
+    ///             .speak(chat, muted: muted)
     ///             .speechToolbarButton(muted: $muted)
     ///             .task {
     ///                 // Add new completed `assistant` content to the `Chat` that is outputted via speech.
@@ -101,7 +100,7 @@ extension View {
     
     return NavigationStack {
         ChatView($chat)
-            .speakChat(chat, muted: muted)
+            .speak(chat, muted: muted)
             .speechToolbarButton(muted: $muted)
     }
 }

--- a/Sources/SpeziChat/ChatView+SpeechButton.swift
+++ b/Sources/SpeziChat/ChatView+SpeechButton.swift
@@ -1,0 +1,82 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+import SpeziSpeechSynthesizer
+
+
+struct ChatViewSpeechButtonModifier: ViewModifier {
+    let enabled: Bool
+    @Binding var muted: Bool
+    
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var speechSynthesizer = SpeechSynthesizer()
+    
+    
+    func body(content: Content) -> some View {
+        content
+            .toolbar {
+                if enabled {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button(action: {
+                            muted.toggle()
+                        }) {
+                            if !muted {
+                                Image(systemName: "speaker")
+                                    .accessibilityLabel(Text("Text to speech is enabled, press to disable text to speech.", bundle: .module))
+                            } else {
+                                Image(systemName: "speaker.slash")
+                                    .accessibilityLabel(Text("Text to speech is disabled, press to enable text to speech.", bundle: .module))
+                            }
+                        }
+                    }
+                }
+            }
+    }
+}
+
+
+extension View {
+    public func speechToolbarButton(
+        enabled: Bool = true,
+        muted: Binding<Bool>
+    ) -> some View {
+        modifier(
+            ChatViewSpeechButtonModifier(
+                enabled: enabled,
+                muted: muted
+            )
+        )
+    }
+}
+
+
+#if DEBUG
+#Preview {
+    @State var chat: Chat = .init(
+        [
+            ChatEntity(role: .system, content: "System Message!"),
+            ChatEntity(role: .system, content: "System Message (hidden)!"),
+            ChatEntity(role: .user, content: "User Message!"),
+            ChatEntity(role: .assistant, content: "Assistant Message!"),
+            ChatEntity(role: .function(name: "test_function"), content: "Function Message!")
+        ]
+    )
+    @State var muted = true
+    
+    
+    return NavigationStack {
+        ChatView(
+            $chat,
+            exportFormat: .pdf
+        )
+            .speakChat(chat, muted: muted)
+            .speechToolbarButton(muted: $muted)
+    }
+}
+#endif

--- a/Sources/SpeziChat/ChatView+SpeechButton.swift
+++ b/Sources/SpeziChat/ChatView+SpeechButton.swift
@@ -7,15 +7,12 @@
 //
 
 import SwiftUI
-import SpeziSpeechSynthesizer
 
 
+/// The underlying `ViewModifier` of `View/speechToolbarButton(enabled:muted:)`.
 struct ChatViewSpeechButtonModifier: ViewModifier {
     let enabled: Bool
     @Binding var muted: Bool
-    
-    @Environment(\.scenePhase) private var scenePhase
-    @State private var speechSynthesizer = SpeechSynthesizer()
     
     
     func body(content: Content) -> some View {
@@ -28,9 +25,11 @@ struct ChatViewSpeechButtonModifier: ViewModifier {
                         }) {
                             if !muted {
                                 Image(systemName: "speaker")
+                                    .accessibilityIdentifier("speaker")
                                     .accessibilityLabel(Text("Text to speech is enabled, press to disable text to speech.", bundle: .module))
                             } else {
                                 Image(systemName: "speaker.slash")
+                                    .accessibilityIdentifier("speaker_slash")
                                     .accessibilityLabel(Text("Text to speech is disabled, press to enable text to speech.", bundle: .module))
                             }
                         }
@@ -42,7 +41,37 @@ struct ChatViewSpeechButtonModifier: ViewModifier {
 
 
 extension View {
-    public func speechToolbarButton(
+    /// Adds a toolbar `Button` to enable or disable text-to-speech capabilities.
+    ///
+    /// When attaching the ``speechToolbarButton(enabled:muted:)`` modifier to a `View` that resides within a SwiftUI `NavigationStack`,
+    /// a `Button` is added to the toolbar that enables text-to-speech capabilities.
+    /// The outside `View` is able to observe taps on that `Button` via passing in a SwiftUI `Binding` as the `muted` parameter, directly tracking the state of the `Button` but also being able to modify it from the outside.
+    /// In addition, the button can be programatically hidden by adjusting the `enabled` parameter at any time.
+    ///
+    /// ### Usage
+    ///
+    /// The code snipped below demonstrates a minimal example of adding a text-to-speech toolbar button that mutes or unmutes text-to-speech output generation.
+    ///
+    /// ```swift
+    /// struct ChatTestView: View {
+    ///     @State private var chat: Chat = [
+    ///         ChatEntity(role: .assistant, content: "**Assistant** Message!")
+    ///     ]
+    ///     @State private var muted = true
+    ///
+    ///
+    ///     var body: some View {
+    ///         ChatView($chat)
+    ///             .speakChat(chat, muted: muted)
+    ///             .speechToolbarButton(muted: $muted)
+    ///             .task {
+    ///                 // Add new completed `assistant` content to the `Chat` that is outputted via speech.
+    ///                 // ...
+    ///             }
+    ///     }
+    /// }
+    /// ```
+    public func speechToolbarButton(    // swiftlint:disable:this function_default_parameter_at_end
         enabled: Bool = true,
         muted: Binding<Bool>
     ) -> some View {
@@ -71,10 +100,7 @@ extension View {
     
     
     return NavigationStack {
-        ChatView(
-            $chat,
-            exportFormat: .pdf
-        )
+        ChatView($chat)
             .speakChat(chat, muted: muted)
             .speechToolbarButton(muted: $muted)
     }

--- a/Sources/SpeziChat/ChatView+SpeechButton.swift
+++ b/Sources/SpeziChat/ChatView+SpeechButton.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 
 /// The underlying `ViewModifier` of `View/speechToolbarButton(enabled:muted:)`.
-struct ChatViewSpeechButtonModifier: ViewModifier {
+private struct ChatViewSpeechButtonModifier: ViewModifier {
     let enabled: Bool
     @Binding var muted: Bool
     

--- a/Sources/SpeziChat/ChatView+SpeechButton.swift
+++ b/Sources/SpeziChat/ChatView+SpeechButton.swift
@@ -25,11 +25,11 @@ struct ChatViewSpeechButtonModifier: ViewModifier {
                         }) {
                             if !muted {
                                 Image(systemName: "speaker")
-                                    .accessibilityIdentifier("speaker")
+                                    .accessibilityIdentifier("Speaker")
                                     .accessibilityLabel(Text("Text to speech is enabled, press to disable text to speech.", bundle: .module))
                             } else {
                                 Image(systemName: "speaker.slash")
-                                    .accessibilityIdentifier("speaker_slash")
+                                    .accessibilityIdentifier("Speaker strikethrough")
                                     .accessibilityLabel(Text("Text to speech is disabled, press to enable text to speech.", bundle: .module))
                             }
                         }

--- a/Sources/SpeziChat/ChatView+SpeechOutput.swift
+++ b/Sources/SpeziChat/ChatView+SpeechOutput.swift
@@ -87,9 +87,13 @@ extension View {
     ///     }
     /// }
     /// ```
+    ///
+    /// - Parameters:
+    ///    - chat: The ``Chat`` which should be used for generating the speech output.
+    ///    - muted: Indicates if the speech output is currently muted, defaults to `false`.
     public func speak(
         _ chat: Chat,
-        muted: Bool
+        muted: Bool = false
     ) -> some View {
         modifier(
             ChatViewSpeechModifier(

--- a/Sources/SpeziChat/ChatView+SpeechOutput.swift
+++ b/Sources/SpeziChat/ChatView+SpeechOutput.swift
@@ -10,7 +10,7 @@ import SpeziSpeechSynthesizer
 import SwiftUI
 
 
-/// The underlying `ViewModifier` of ``ChatView/speakChat(_:muted:)``.
+/// The underlying `ViewModifier` of ``ChatView/speak(_:muted:)``.
 struct ChatViewSpeechModifier: ViewModifier {
     let chat: Chat
     let muted: Bool
@@ -56,16 +56,16 @@ struct ChatViewSpeechModifier: ViewModifier {
 extension ChatView {
     /// Provides text-to-speech capabilities to the ``ChatView``.
     ///
-    /// Attaching the modifier to a ``ChatView`` will enable the automatic output of the latest added ``ChatEntity/Role-swift.enum/assistant`` chat message that is ``ChatEntity/complete`` within the passed ``Chat``.
-    /// The text-to-speech capability can be muted via a `Bool` flag in the ``speakChat(_:muted:)`` modifier.
+    /// Attaching the modifier to a ``ChatView`` will enable the automatic speech output of the latest added ``ChatEntity/Role-swift.enum/assistant`` ``Chat`` message that is ``ChatEntity/complete``.
+    /// The text-to-speech capability can be muted via a `Bool` flag in the ``speak(_:muted:)`` modifier.
     ///
-    /// It is important to note that only the latest ``ChatEntity/Role-swift.enum/assistant`` and ``ChatEntity/complete`` ``Chat`` messages will be synthezised to natural language speech.
+    /// It is important to note that only the latest ``ChatEntity/Role-swift.enum/assistant`` and ``ChatEntity/complete`` ``Chat`` messages will be synthezised to natural language speech, as soon as it is persisted in the ``Chat``.
     /// The speech output is immediately stopped as soon as a ``ChatEntity/complete`` ``ChatEntity/Role-swift.enum/user`` message is added to the ``Chat``,
-    /// the passed in `muted` `Binding` turns to `true`, or the `View` is inactive or in the background.
+    /// the passed `muted` `Binding` turns to `true`, or the `View` becomes inactive or is moved to the background.
     ///
     /// ### Usage
     ///
-    /// The code snipped below demonstrates a minimal example of text-to-speech capabilities. At first, the speech output is muted, only after ten seconds speech output of newly incoming ``Chat`` messages will be synthezised.
+    /// The code snipped below demonstrates a minimal example of text-to-speech capabilities. At first, the speech output is muted, only after ten seconds the speech output of newly incoming ``Chat`` messages will be synthezised.
     ///
     /// ```swift
     /// struct ChatTestView: View {
@@ -74,10 +74,9 @@ extension ChatView {
     ///     ]
     ///     @State private var muted = true
     ///
-    ///
     ///     var body: some View {
     ///         ChatView($chat)
-    ///             .speakChat(chat, muted: muted)
+    ///             .speak(chat, muted: muted)
     ///             .task {
     ///                 try? await Task.sleep(for: .seconds(10))
     ///                 muted = false
@@ -88,7 +87,7 @@ extension ChatView {
     ///     }
     /// }
     /// ```
-    public func speakChat(
+    public func speak(
         _ chat: Chat,
         muted: Bool
     ) -> some View {
@@ -130,7 +129,7 @@ extension ChatView {
     
     return NavigationStack {
         ChatView($chat)
-            .speakChat(chat, muted: muted)
+            .speak(chat, muted: muted)
     }
 }
 
@@ -145,7 +144,7 @@ extension ChatView {
     
     return NavigationStack {
         ChatView($chat)
-            .speakChat(chat, muted: muted)
+            .speak(chat, muted: muted)
     }
 }
 #endif

--- a/Sources/SpeziChat/ChatView+SpeechOutput.swift
+++ b/Sources/SpeziChat/ChatView+SpeechOutput.swift
@@ -10,8 +10,8 @@ import SpeziSpeechSynthesizer
 import SwiftUI
 
 
-/// The underlying `ViewModifier` of ``ChatView/speak(_:muted:)``.
-struct ChatViewSpeechModifier: ViewModifier {
+/// The underlying `ViewModifier` of `View/speak(_:muted:)`.
+private struct ChatViewSpeechModifier: ViewModifier {
     let chat: Chat
     let muted: Bool
     
@@ -53,7 +53,7 @@ struct ChatViewSpeechModifier: ViewModifier {
 }
 
 
-extension ChatView {
+extension View {
     /// Provides text-to-speech capabilities to the ``ChatView``.
     ///
     /// Attaching the modifier to a ``ChatView`` will enable the automatic speech output of the latest added ``ChatEntity/Role-swift.enum/assistant`` ``Chat`` message that is ``ChatEntity/complete``.

--- a/Sources/SpeziChat/ChatView+SpeechOutput.swift
+++ b/Sources/SpeziChat/ChatView+SpeechOutput.swift
@@ -6,10 +6,11 @@
 // SPDX-License-Identifier: MIT
 //
 
-import SwiftUI
 import SpeziSpeechSynthesizer
+import SwiftUI
 
 
+/// The underlying `ViewModifier` of ``ChatView/speakChat(_:muted:)``.
 struct ChatViewSpeechModifier: ViewModifier {
     let chat: Chat
     let muted: Bool
@@ -22,7 +23,7 @@ struct ChatViewSpeechModifier: ViewModifier {
         content
             // Output speech when new complete assistant message is the last message
             // Cancel speech output as soon as new message arrives with user role
-            .onChange(of: chat, initial: true) { _, newValue in
+            .onChange(of: chat, initial: true) { _, _ in
                 guard !muted,
                       let lastChatEntity = chat.last,
                       lastChatEntity.complete else {
@@ -53,6 +54,40 @@ struct ChatViewSpeechModifier: ViewModifier {
 
 
 extension ChatView {
+    /// Provides text-to-speech capabilities to the ``ChatView``.
+    ///
+    /// Attaching the modifier to a ``ChatView`` will enable the automatic output of the latest added ``ChatEntity/Role-swift.enum/assistant`` chat message that is ``ChatEntity/complete`` within the passed ``Chat``.
+    /// The text-to-speech capability can be muted via a `Bool` flag in the ``speakChat(_:muted:)`` modifier.
+    ///
+    /// It is important to note that only the latest ``ChatEntity/Role-swift.enum/assistant`` and ``ChatEntity/complete`` ``Chat`` messages will be synthezised to natural language speech.
+    /// The speech output is immediately stopped as soon as a ``ChatEntity/complete`` ``ChatEntity/Role-swift.enum/user`` message is added to the ``Chat``,
+    /// the passed in `muted` `Binding` turns to `true`, or the `View` is inactive or in the background.
+    ///
+    /// ### Usage
+    ///
+    /// The code snipped below demonstrates a minimal example of text-to-speech capabilities. At first, the speech output is muted, only after ten seconds speech output of newly incoming ``Chat`` messages will be synthezised.
+    ///
+    /// ```swift
+    /// struct ChatTestView: View {
+    ///     @State private var chat: Chat = [
+    ///         ChatEntity(role: .assistant, content: "**Assistant** Message!")
+    ///     ]
+    ///     @State private var muted = true
+    ///
+    ///
+    ///     var body: some View {
+    ///         ChatView($chat)
+    ///             .speakChat(chat, muted: muted)
+    ///             .task {
+    ///                 try? await Task.sleep(for: .seconds(10))
+    ///                 muted = false
+    ///
+    ///                 // Add new completed `assistant` content to the `Chat` that is outputted via speech.
+    ///                 // ...
+    ///             }
+    ///     }
+    /// }
+    /// ```
     public func speakChat(
         _ chat: Chat,
         muted: Bool
@@ -80,10 +115,7 @@ extension ChatView {
     )
     
     return NavigationStack {
-        ChatView(
-            $chat,
-            exportFormat: .pdf
-        )
+        ChatView($chat)
     }
 }
 
@@ -97,10 +129,7 @@ extension ChatView {
     
     
     return NavigationStack {
-        ChatView(
-            $chat,
-            exportFormat: .pdf
-        )
+        ChatView($chat)
             .speakChat(chat, muted: muted)
     }
 }
@@ -115,10 +144,7 @@ extension ChatView {
     
     
     return NavigationStack {
-        ChatView(
-            $chat,
-            exportFormat: .pdf
-        )
+        ChatView($chat)
             .speakChat(chat, muted: muted)
     }
 }

--- a/Sources/SpeziChat/ChatView+SpeechOutput.swift
+++ b/Sources/SpeziChat/ChatView+SpeechOutput.swift
@@ -59,13 +59,13 @@ extension ChatView {
     /// Attaching the modifier to a ``ChatView`` will enable the automatic speech output of the latest added ``ChatEntity/Role-swift.enum/assistant`` ``Chat`` message that is ``ChatEntity/complete``.
     /// The text-to-speech capability can be muted via a `Bool` flag in the ``speak(_:muted:)`` modifier.
     ///
-    /// It is important to note that only the latest ``ChatEntity/Role-swift.enum/assistant`` and ``ChatEntity/complete`` ``Chat`` messages will be synthezised to natural language speech, as soon as it is persisted in the ``Chat``.
+    /// It is important to note that only the latest ``ChatEntity/Role-swift.enum/assistant`` and ``ChatEntity/complete`` ``Chat`` messages will be synthesized to natural language speech, as soon as it is persisted in the ``Chat``.
     /// The speech output is immediately stopped as soon as a ``ChatEntity/complete`` ``ChatEntity/Role-swift.enum/user`` message is added to the ``Chat``,
     /// the passed `muted` `Binding` turns to `true`, or the `View` becomes inactive or is moved to the background.
     ///
     /// ### Usage
     ///
-    /// The code snipped below demonstrates a minimal example of text-to-speech capabilities. At first, the speech output is muted, only after ten seconds the speech output of newly incoming ``Chat`` messages will be synthezised.
+    /// The code snipped below demonstrates a minimal example of text-to-speech capabilities. At first, the speech output is muted, only after ten seconds the speech output of newly incoming ``Chat`` messages will be synthesized.
     ///
     /// ```swift
     /// struct ChatTestView: View {

--- a/Sources/SpeziChat/ChatView+SpeechOutput.swift
+++ b/Sources/SpeziChat/ChatView+SpeechOutput.swift
@@ -1,0 +1,125 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+import SpeziSpeechSynthesizer
+
+
+struct ChatViewSpeechModifier: ViewModifier {
+    let chat: Chat
+    let muted: Bool
+    
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var speechSynthesizer = SpeechSynthesizer()
+    
+    
+    func body(content: Content) -> some View {
+        content
+            // Output speech when new complete assistant message is the last message
+            // Cancel speech output as soon as new message arrives with user role
+            .onChange(of: chat, initial: true) { _, newValue in
+                guard !muted,
+                      let lastChatEntity = chat.last,
+                      lastChatEntity.complete else {
+                    return
+                }
+                
+                if lastChatEntity.role == .assistant {
+                    speechSynthesizer.speak(lastChatEntity.content)
+                } else if lastChatEntity.role == .user {
+                    speechSynthesizer.stop()
+                }
+            }
+            // Cancel speech output when muted button is tapped in the toolbar
+            .onChange(of: muted) { _, newValue in
+                if newValue {
+                    speechSynthesizer.stop()
+                }
+            }
+            // Cancel speech output when view disappears
+            .onChange(of: scenePhase) { _, newValue in
+                switch newValue {
+                case .background, .inactive: speechSynthesizer.stop()
+                default: break
+                }
+            }
+    }
+}
+
+
+extension ChatView {
+    public func speakChat(
+        _ chat: Chat,
+        muted: Bool
+    ) -> some View {
+        modifier(
+            ChatViewSpeechModifier(
+                chat: chat,
+                muted: muted
+            )
+        )
+    }
+}
+
+
+#if DEBUG
+#Preview("ChatView") {
+    @State var chat: Chat = .init(
+        [
+            ChatEntity(role: .system, content: "System Message!"),
+            ChatEntity(role: .system, content: "System Message (hidden)!"),
+            ChatEntity(role: .user, content: "User Message!"),
+            ChatEntity(role: .assistant, content: "Assistant Message!"),
+            ChatEntity(role: .function(name: "test_function"), content: "Function Message!")
+        ]
+    )
+    
+    return NavigationStack {
+        ChatView(
+            $chat,
+            exportFormat: .pdf
+        )
+    }
+}
+
+#Preview("ChatViewSpeechOutput") {
+    @State var chat: Chat = .init(
+        [
+            ChatEntity(role: .assistant, content: "Assistant Message!")
+        ]
+    )
+    @State var muted = false
+    
+    
+    return NavigationStack {
+        ChatView(
+            $chat,
+            exportFormat: .pdf
+        )
+            .speakChat(chat, muted: muted)
+    }
+}
+
+#Preview("ChatViewSpeechOutputDisabled") {
+    @State var chat: Chat = .init(
+        [
+            ChatEntity(role: .assistant, content: "Assistant Message!")
+        ]
+    )
+    @State var muted = true
+    
+    
+    return NavigationStack {
+        ChatView(
+            $chat,
+            exportFormat: .pdf
+        )
+            .speakChat(chat, muted: muted)
+    }
+}
+#endif

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -35,8 +35,32 @@ import SwiftUI
 ///
 /// ### Accessibility
 ///
-/// The ``ChatView`` provides speech-to-text (recognition) as well as text-to-speech  (synthesize) capabilities out of the box via the [`SpeziSpeech`](https://github.com/StanfordSpezi/SpeziSpeech) module, facilitating seamless interaction with the content of the ``ChatView``.
+/// The ``ChatView`` provides speech-to-text (recognition) as well as text-to-speech (synthesize) capabilities out of the box via the [`SpeziSpeech`](https://github.com/StanfordSpezi/SpeziSpeech) module, facilitating seamless interaction with the content of the ``ChatView``.
 /// 
+/// Speech-to-text capabilities can be activated via the `speechToText` `Bool` parameter in ``init(_:disableInput:speechToText:exportFormat:messagePlaceholder:messagePendingAnimation:)``. By default, this capability is activated and therefore a small microphone button is shown next to the text input field.
+///
+/// Text-to-speech capabilities can be configured via the ``ChatView/speak(_:muted:)`` `ViewModifier`. If present, the latest ``ChatEntity/complete`` ``ChatEntity/Role-swift.enum/assistant`` message in the ``Chat`` will be synthesized to natural language speech.
+/// In addition, the `View/speechToolbarButton(enabled:muted:)` `ViewModifier` automatically adds a toolbar `Button` to mute or unmute the speech synthesizer, if not disabled via the `enabled` parameter.
+/// The `muted` flag enables to track the state of the `Button` or adjust it from the outside.
+///
+/// ```swift
+/// struct ChatTestView: View {
+///     @State private var chat: Chat = [
+///         ChatEntity(role: .assistant, content: "**Assistant** Message!")
+///     ]
+///     @State private var muted = true
+///
+///     var body: some View {
+///         ChatView($chat)
+///             .speak(chat, muted: muted)
+///             .speechToolbarButton(muted: $muted)
+///             .task {
+///                 // Add new completed `assistant` content to the `Chat` that is outputted via speech.
+///                 // ...
+///             }
+///     }
+/// }
+/// ```
 ///
 /// ### Export of Chat
 ///

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import SpeziSpeechSynthesizer
 
 
 /// Provides a basic reusable chat view which includes a message input field. The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
@@ -32,6 +33,11 @@ import SwiftUI
 /// }
 /// ```
 ///
+/// ### Accessibility
+///
+/// The ``ChatView`` provides speech-to-text (recognition) as well as text-to-speech  (synthesize) capabilities out of the box via the [`SpeziSpeech`](https://github.com/StanfordSpezi/SpeziSpeech) module, facilitating seamless interaction with the content of the ``ChatView``.
+/// 
+///
 /// ### Export of Chat
 ///
 /// The ``ChatView`` provides functionality to export the visualized ``Chat`` as a PDF document, JSON representation, or textual UTF-8 file (see ``ChatView/ChatExportFormat``).
@@ -55,12 +61,13 @@ import SwiftUI
 /// ```
 public struct ChatView: View {
     @Binding var chat: Chat
-    var disableInput: Bool
+    private var disableInput: Bool
+    private let speechToText: Bool
     let exportFormat: ChatExportFormat?
-    let messagePlaceholder: String?
-    let messagePendingAnimation: MessagesView.TypingIndicatorDisplayMode?
+    private let messagePlaceholder: String?
+    private let messagePendingAnimation: MessagesView.TypingIndicatorDisplayMode?
     
-    @State var messageInputHeight: CGFloat = 0
+    @State private var messageInputHeight: CGFloat = 0
     @State private var showShareSheet = false
     
     
@@ -88,28 +95,28 @@ public struct ChatView: View {
                     }
             }
         }
-        .toolbar {
-            if exportEnabled {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button(action: {
-                        showShareSheet = true
-                    }) {
-                        Image(systemName: "square.and.arrow.up")
-                            .accessibilityLabel(Text("EXPORT_CHAT_BUTTON", bundle: .module))
+            .toolbar {
+                if exportEnabled {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button(action: {
+                            showShareSheet = true
+                        }) {
+                            Image(systemName: "square.and.arrow.up")
+                                .accessibilityLabel(Text("EXPORT_CHAT_BUTTON", bundle: .module))
+                        }
                     }
                 }
             }
-        }
-        .sheet(isPresented: $showShareSheet) {
-            if let exportedChatData, let exportFormat {
-                ShareSheet(sharedItem: exportedChatData, sharedItemType: exportFormat)
-                    .presentationDetents([.medium])
-            } else {
-                ProgressView()
-                    .padding()
-                    .presentationDetents([.medium])
+            .sheet(isPresented: $showShareSheet) {
+                if let exportedChatData, let exportFormat {
+                    ShareSheet(sharedItem: exportedChatData, sharedItemType: exportFormat)
+                        .presentationDetents([.medium])
+                } else {
+                    ProgressView()
+                        .padding()
+                        .presentationDetents([.medium])
+                }
             }
-        }
     }
     
     private var exportEnabled: Bool {
@@ -122,18 +129,21 @@ public struct ChatView: View {
     /// - Parameters:
     ///   - chat: The chat that should be displayed.
     ///   - disableInput: Flag if the input view should be disabled.
+    ///   - speechToText: Enables speech-to-text (recognition) capabilities of the input field, defaults to `true`.
     ///   - exportFormat: If specified, enables the export of the ``Chat`` displayed in the ``ChatView`` via a share sheet in various formats defined in ``ChatView/ChatExportFormat``.
     ///   - messagePlaceholder: Placeholder text that should be added in the input field.
     ///   - messagePendingAnimation: Parameter to control whether a chat bubble animation is shown.
     public init(
         _ chat: Binding<Chat>,
         disableInput: Bool = false,
+        speechToText: Bool = true,
         exportFormat: ChatExportFormat? = nil,
         messagePlaceholder: String? = nil,
         messagePendingAnimation: MessagesView.TypingIndicatorDisplayMode? = nil
     ) {
         self._chat = chat
         self.disableInput = disableInput
+        self.speechToText = speechToText
         self.exportFormat = exportFormat
         self.messagePlaceholder = messagePlaceholder
         self.messagePendingAnimation = messagePendingAnimation
@@ -141,6 +151,7 @@ public struct ChatView: View {
 }
 
 
+#if DEBUG
 #Preview {
     NavigationStack {
         ChatView(
@@ -157,3 +168,4 @@ public struct ChatView: View {
         )
     }
 }
+#endif

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -6,8 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-import SwiftUI
 import SpeziSpeechSynthesizer
+import SwiftUI
 
 
 /// Provides a basic reusable chat view which includes a message input field. The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -39,7 +39,7 @@ import SwiftUI
 /// 
 /// Speech-to-text capabilities can be activated via the `speechToText` `Bool` parameter in ``init(_:disableInput:speechToText:exportFormat:messagePlaceholder:messagePendingAnimation:)``. By default, this capability is activated and therefore a small microphone button is shown next to the text input field.
 ///
-/// Text-to-speech capabilities can be configured via the ``ChatView/speak(_:muted:)`` `ViewModifier`. If present, the latest ``ChatEntity/complete`` ``ChatEntity/Role-swift.enum/assistant`` message in the ``Chat`` will be synthesized to natural language speech.
+/// Text-to-speech capabilities can be configured via the `View/speak(_:muted:)` `ViewModifier`. If present, the latest ``ChatEntity/complete`` ``ChatEntity/Role-swift.enum/assistant`` message in the ``Chat`` will be synthesized to natural language speech.
 /// In addition, the `View/speechToolbarButton(enabled:muted:)` `ViewModifier` automatically adds a toolbar `Button` to mute or unmute the speech synthesizer, if not disabled via the `enabled` parameter.
 /// The `muted` flag enables to track the state of the `Button` or adjust it from the outside.
 ///

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -48,7 +48,7 @@ import SwiftUI
 ///     @State private var chat: Chat = [
 ///         ChatEntity(role: .assistant, content: "**Assistant** Message!")
 ///     ]
-///     @State private var muted = true
+///     @State private var muted = false
 ///
 ///     var body: some View {
 ///         ChatView($chat)
@@ -112,7 +112,7 @@ public struct ChatView: View {
             }
             VStack {
                 Spacer()
-                MessageInputView($chat, messagePlaceholder: messagePlaceholder)
+                MessageInputView($chat, messagePlaceholder: messagePlaceholder, speechToText: speechToText)
                     .disabled(disableInput)
                     .onPreferenceChange(MessageInputViewHeightKey.self) { newValue in
                         messageInputHeight = newValue + 12

--- a/Sources/SpeziChat/Helpers/TypingIndicator.swift
+++ b/Sources/SpeziChat/Helpers/TypingIndicator.swift
@@ -26,6 +26,7 @@ import SwiftUI
 public struct TypingIndicator: View {
     @State var isAnimating = false
     
+    
     public var body: some View {
         HStack {
             HStack(spacing: 3) {
@@ -42,19 +43,22 @@ public struct TypingIndicator: View {
                         )
                         .frame(width: 10)
                 }
-                .accessibilityIdentifier(String(localized: "TYPING_INDICATOR", bundle: .module))
+                    .accessibilityIdentifier(String(localized: "TYPING_INDICATOR", bundle: .module))
             }
-            .frame(width: 42, height: 12, alignment: .center)
-            .padding(.vertical, 4)
-            .onAppear {
-                self.isAnimating = true
-            }
-            .chatMessageStyle(alignment: .leading)
+                .frame(width: 42, height: 12, alignment: .center)
+                .padding(.vertical, 4)
+                .onAppear {
+                    self.isAnimating = true
+                }
+                .chatMessageStyle(alignment: .leading)
+            
             Spacer(minLength: 32)
         }
     }
 }
 
+
+#if DEBUG
 #Preview {
     ScrollView {
         VStack {
@@ -67,3 +71,4 @@ public struct TypingIndicator: View {
         .padding()
     }
 }
+#endif

--- a/Sources/SpeziChat/MessageInputView.swift
+++ b/Sources/SpeziChat/MessageInputView.swift
@@ -15,10 +15,11 @@ import SwiftUI
 /// A reusable SwiftUI `View` to handle text-based or speech-based user input.
 /// The provided message is attached to the passed ``Chat`` via a SwiftUI `Binding`.
 ///
-/// The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
+/// The input can be either typed out via the iOS keyboard or, if enabled (which is the case by default), provided as voice input and transcribed into written text via the [`SpeziSpeech`](https://github.com/StanfordSpezi/SpeziSpeech) module.
 ///
 /// One can get the size of the typed message, which can vary dependent on the message length, via the ``MessageInputViewHeightKey`` SwiftUI PreferenceKey`.
 ///
+/// ### Usage
 ///
 /// ```swift
 /// struct MessageInputTestView: View {
@@ -44,6 +45,7 @@ import SwiftUI
 public struct MessageInputView: View {
     @Binding private var chat: Chat
     private let messagePlaceholder: String
+    private let speechToText: Bool
     
     @State private var speechRecognizer = SpeechRecognizer()
     @State private var message: String = ""
@@ -68,7 +70,9 @@ public struct MessageInputView: View {
                 }
                 .lineLimit(1...5)
             Group {
-                if speechRecognizer.isAvailable && (message.isEmpty || speechRecognizer.isRecording) {
+                if speechToText,
+                   speechRecognizer.isAvailable,
+                   message.isEmpty || speechRecognizer.isRecording {
                     microphoneButton
                 } else {
                     sendButton
@@ -138,12 +142,15 @@ public struct MessageInputView: View {
     /// - Parameters:
     ///   - chat: The chat that should be appended to.
     ///   - messagePlaceholder: Placeholder text that should be added in the input field
+    ///   - speechToText: Enables speech-to-text (recognition) capabilities of the input field.
     public init(
         _ chat: Binding<Chat>,
-        messagePlaceholder: String? = nil
+        messagePlaceholder: String? = nil,
+        speechToText: Bool = true
     ) {
         self._chat = chat
         self.messagePlaceholder = messagePlaceholder ?? "Message"
+        self.speechToText = speechToText
     }
     
     
@@ -173,6 +180,7 @@ public struct MessageInputView: View {
 }
 
 
+#if DEBUG
 #Preview {
     @State var chat = [
         ChatEntity(role: .system, content: "System Message!"),
@@ -195,3 +203,4 @@ public struct MessageInputView: View {
             }
     }
 }
+#endif

--- a/Sources/SpeziChat/MessageView.swift
+++ b/Sources/SpeziChat/MessageView.swift
@@ -13,6 +13,7 @@ import SwiftUI
 ///
 /// Messages with specific system ``ChatEntity/Role``s are hidden. Those ``ChatEntity/Role``s are configurable via a parameter.
 /// 
+/// ### Usage
 ///
 /// ```swift
 /// struct MessageViewTestView: View {
@@ -68,6 +69,7 @@ public struct MessageView: View {
 }
 
 
+#if DEBUG
 #Preview {
     ScrollView {
         VStack {
@@ -82,3 +84,4 @@ public struct MessageView: View {
             .padding()
     }
 }
+#endif

--- a/Sources/SpeziChat/MessagesView.swift
+++ b/Sources/SpeziChat/MessagesView.swift
@@ -16,6 +16,7 @@ import SwiftUI
 /// Depending on the parameters, ``ChatEntity``s with certain ``ChatEntity/Role``s are hidden from the `View`.
 /// The ``MessagesView`` is shifted from the bottom by a configurable parameter which is important for input fields, e.g., ``MessageInputView``.
 ///
+/// ### Usage
 ///
 /// ```swift
 /// struct MessagesViewTestView: View {
@@ -68,7 +69,10 @@ public struct MessagesView: View {
     private var shouldDisplayTypingIndicator: Bool {
         switch self.typingIndicator {
         case .automatic:
-            self.chat.last?.role == .user
+            switch self.chat.last?.role {
+            case .user, .function: true
+            default: false
+            }
         case .manual(let shouldDisplay):
             shouldDisplay
         case .none:
@@ -148,6 +152,7 @@ public struct MessagesView: View {
 }
 
 
+#if DEBUG
 #Preview {
     MessagesView(
         [
@@ -159,3 +164,4 @@ public struct MessagesView: View {
         ]
     )
 }
+#endif

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -13,6 +13,7 @@ import Foundation
 ///
 /// A ``ChatEntity`` can be thought of as a single message entity within a ``Chat``
 /// It consists of a ``ChatEntity/Role``, a timestamp in the form of a `Date` as well as an `String`-based ``ChatEntity/content`` property which can contain Markdown-formatted text.
+/// Furthermore, the ``ChatEntity/complete`` flag indicates if the current state of the ``ChatEntity`` is final and the content will not be updated anymore.
 public struct ChatEntity: Codable, Equatable, Hashable {
     /// Indicates which ``ChatEntity/Role`` is associated with a ``ChatEntity``.
     public enum Role: Codable, Equatable, Hashable {
@@ -39,6 +40,8 @@ public struct ChatEntity: Codable, Equatable, Hashable {
     public let content: String
     /// The creation date of the ``ChatEntity``.
     public let date: Date
+    /// Indicates if the ``ChatEntity`` is complete and will not receive any additional content.
+    public let complete: Bool
     
     
     /// Markdown-formatted ``ChatEntity/content`` as an `AttributedString`, required to render the text in Markdown-style within the ``MessageView``.
@@ -61,9 +64,11 @@ public struct ChatEntity: Codable, Equatable, Hashable {
     /// - Parameters:
     ///    - role: ``ChatEntity/Role`` associated with the ``ChatEntity``.
     ///    - content: `String`-based content of the ``ChatEntity``. Can contain Markdown-formatted text.
-    public init<Content: StringProtocol>(role: Role, content: Content) {
+    ///    - complete: Indicates if the content of the ``ChatEntity`` is complete and will not receive any additional content. Defaults to `true`.
+    public init<Content: StringProtocol>(role: Role, content: Content, complete: Bool = true) {
         self.role = role
         self.content = String(content)
+        self.complete = complete
         self.date = Date()
     }
 }

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -14,7 +14,7 @@ import Foundation
 /// A ``ChatEntity`` can be thought of as a single message entity within a ``Chat``
 /// It consists of a ``ChatEntity/Role``, a timestamp in the form of a `Date` as well as an `String`-based ``ChatEntity/content`` property which can contain Markdown-formatted text.
 /// Furthermore, the ``ChatEntity/complete`` flag indicates if the current state of the ``ChatEntity`` is final and the content will not be updated anymore.
-public struct ChatEntity: Codable, Equatable, Hashable {
+public struct ChatEntity: Codable, Equatable, Hashable, Identifiable {
     /// Indicates which ``ChatEntity/Role`` is associated with a ``ChatEntity``.
     public enum Role: Codable, Equatable, Hashable {
         case system
@@ -33,7 +33,8 @@ public struct ChatEntity: Codable, Equatable, Hashable {
         }
     }
     
-    
+    /// Unique identifier of the ``ChatEntity``
+    public let id: UUID
     /// ``ChatEntity/Role`` associated with the ``ChatEntity``.
     public let role: Role
     /// `String`-based content of the ``ChatEntity``.
@@ -66,6 +67,7 @@ public struct ChatEntity: Codable, Equatable, Hashable {
     ///    - content: `String`-based content of the ``ChatEntity``. Can contain Markdown-formatted text.
     ///    - complete: Indicates if the content of the ``ChatEntity`` is complete and will not receive any additional content. Defaults to `true`.
     public init<Content: StringProtocol>(role: Role, content: Content, complete: Bool = true) {
+        self.id = UUID()
         self.role = role
         self.content = String(content)
         self.complete = complete

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -33,7 +33,7 @@ public struct ChatEntity: Codable, Equatable, Hashable, Identifiable {
         }
     }
     
-    /// Unique identifier of the ``ChatEntity``
+    /// Unique identifier of the ``ChatEntity``.
     public let id: UUID
     /// ``ChatEntity/Role`` associated with the ``ChatEntity``.
     public let role: Role

--- a/Sources/SpeziChat/Resources/Localizable.xcstrings
+++ b/Sources/SpeziChat/Resources/Localizable.xcstrings
@@ -87,6 +87,12 @@
         }
       }
     },
+    "Text to speech is disabled, press to enable text to speech." : {
+
+    },
+    "Text to speech is enabled, press to disable text to speech." : {
+
+    },
     "TYPING_INDICATOR" : {
       "localizations" : {
         "en" : {

--- a/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
+++ b/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
@@ -58,7 +58,7 @@ These entries are mandatory for apps that utilize microphone and speech recognit
 ## Usage
 
 The underlying data model of ``SpeziChat`` is a ``Chat``. It represents the content of a typical text-based chat between user and system(s). A ``Chat`` is nothing more than an ordered array of ``ChatEntity``s which contain the content of the individual messages.
-A ``ChatEntity`` consists of a ``ChatEntity/Role-swift.enum``, a timestamp as well as an `String`-based content which can contain Markdown-formatted text.
+A ``ChatEntity`` consists of a ``ChatEntity/Role-swift.enum``, a timestamp as well as an `String`-based content which can contain Markdown-formatted text. In addition, a flag indicates if the `ChatEntity` is complete and no further content will be added.
 
 > Tip: The ``ChatEntity`` is able to store Markdown-based content which in turn is rendered as styled text in the ``ChatView``, ``MessagesView``, and ``MessageView``.
 
@@ -80,6 +80,8 @@ struct ChatTestView: View {
     }
 }
 ```
+
+- Tip: The ``ChatView`` provides speech-to-text (recognition) as well as text-to-speech (synthesize) accessibility capabilities out-of-the-box via the [`SpeziSpeech`](https://github.com/StanfordSpezi/SpeziSpeech) module, facilitating seamless interaction with the content of the ``ChatView``.
 
 ### Messages View
 
@@ -151,12 +153,16 @@ struct MessageInputTestView: View {
 - ``MessagesView``
 - ``MessageView``
 
+### Message models
+
+- ``Chat``
+- ``ChatEntity``
+
 ### User input
 
 - ``MessageInputView``
 - ``MessageInputViewHeightKey``
 
-### Message models
+### Accessibility
 
-- ``Chat``
-- ``ChatEntity``
+- ``ChatView/speak(_:muted:)``

--- a/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
+++ b/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
@@ -162,7 +162,3 @@ struct MessageInputTestView: View {
 
 - ``MessageInputView``
 - ``MessageInputViewHeightKey``
-
-### Accessibility
-
-- ``ChatView/speak(_:muted:)``

--- a/Tests/UITests/TestApp/ChatTestView.swift
+++ b/Tests/UITests/TestApp/ChatTestView.swift
@@ -14,14 +14,21 @@ struct ChatTestView: View {
     @State private var chat: Chat = [
         ChatEntity(role: .assistant, content: "**Assistant** Message!")
     ]
+    @State private var muted = true
     
     
     var body: some View {
-        ChatView($chat, exportFormat: .pdf, messagePendingAnimation: .automatic)
+        ChatView(
+            $chat,
+            exportFormat: .pdf,
+            messagePendingAnimation: .automatic
+        )
+            .speakChat(chat, muted: muted)
+            .speechToolbarButton(muted: $muted)
             .navigationTitle("SpeziChat")
             .padding(.top, 16)
             .onChange(of: chat) { _, newValue in
-                /// Append a new assistant message to the chat after sleeping for 1 second.
+                /// Append a new assistant message to the chat after sleeping for 5 seconds.
                 if newValue.last?.role == .user {
                     Task {
                         try await Task.sleep(for: .seconds(5))
@@ -36,6 +43,8 @@ struct ChatTestView: View {
 }
 
 
+#if DEBUG
 #Preview {
     ChatTestView()
 }
+#endif

--- a/Tests/UITests/TestApp/ChatTestView.swift
+++ b/Tests/UITests/TestApp/ChatTestView.swift
@@ -23,7 +23,7 @@ struct ChatTestView: View {
             exportFormat: .pdf,
             messagePendingAnimation: .automatic
         )
-            .speakChat(chat, muted: muted)
+            .speak(chat, muted: muted)
             .speechToolbarButton(muted: $muted)
             .navigationTitle("SpeziChat")
             .padding(.top, 16)

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -118,12 +118,12 @@ class TestAppUITests: XCTestCase {
         app.launch()
         
         XCTAssert(app.staticTexts["SpeziChat"].waitForExistence(timeout: 1))
-        XCTAssert(app.buttons["speaker_slash"].waitForExistence(timeout: 2))
-        XCTAssert(!app.buttons["speaker"].waitForExistence(timeout: 2))
+        XCTAssert(app.buttons["Speaker strikethrough"].waitForExistence(timeout: 2))
+        XCTAssert(!app.buttons["Speaker"].waitForExistence(timeout: 2))
         
-        app.buttons["speaker_slash"].tap()
+        app.buttons["Speaker strikethrough"].tap()
         
-        XCTAssert(!app.buttons["speaker_slash"].waitForExistence(timeout: 2))
-        XCTAssert(app.buttons["speaker"].waitForExistence(timeout: 2))
+        XCTAssert(!app.buttons["Speaker strikethrough"].waitForExistence(timeout: 2))
+        XCTAssert(app.buttons["Speaker"].waitForExistence(timeout: 2))
     }
 }

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -112,4 +112,18 @@ class TestAppUITests: XCTestCase {
         XCTAssert(filesApp.buttons["Done"].waitForExistence(timeout: 2))
         filesApp.buttons["Done"].tap()
     }
+    
+    func testChatSpeechOutput() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        XCTAssert(app.staticTexts["SpeziChat"].waitForExistence(timeout: 1))
+        XCTAssert(app.buttons["speaker_slash"].waitForExistence(timeout: 2))
+        XCTAssert(!app.buttons["speaker"].waitForExistence(timeout: 2))
+        
+        app.buttons["speaker_slash"].tap()
+        
+        XCTAssert(!app.buttons["speaker_slash"].waitForExistence(timeout: 2))
+        XCTAssert(app.buttons["speaker"].waitForExistence(timeout: 2))
+    }
 }


### PR DESCRIPTION
# Text-to-speech capabilities

## :recycle: Current situation & Problem
Currently, SpeziChat provides speech-to-text capabilities but no integration with the text-to-speech capabilities of SpeziSpeech.


## :gear: Release Notes 
- Add text-to-speech capabilities to the `ChatView` via the `.speak()` and `.speechToolbarButton()` view modifiers


## :books: Documentation
Added inline Docs


## :white_check_mark: Testing
Adjusted UI tests


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
