### PR TITLE
Make ID and Timestamp of ChatEntity configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ These entries are mandatory for apps that utilize microphone and speech recognit
 ## Usage
 
 The underlying data model of [SpeziChat](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat) is a [`Chat`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chat). It represents the content of a typical text-based chat between user and system(s). A `Chat` is nothing more than an ordered array of [`ChatEntity`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity)s which contain the content of the individual messages.
-A `ChatEntity` consists of a [`ChatEntity/Role`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity/role-swift.enum), a timestamp as well as an `String`-based content which can contain Markdown-formatted text. In addition, a flag indicates if the `ChatEntity` is complete and no further content will be added.
+A `ChatEntity` consists of a [`ChatEntity/Role`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity/role-swift.enum), a unique identifier, a timestamp as well as an `String`-based content which can contain Markdown-formatted text. In addition, a flag indicates if the `ChatEntity` is complete and no further content will be added.
 
 > [!NOTE]  
 > The [`ChatEntity`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatentity) is able to store Markdown-based content which in turn is rendered as styled text in the `ChatView`, `MessagesView`, and `MessageView`.

--- a/Sources/SpeziChat/ChatView+SpeechButton.swift
+++ b/Sources/SpeziChat/ChatView+SpeechButton.swift
@@ -40,7 +40,7 @@ private struct ChatViewSpeechButtonModifier: ViewModifier {
 extension View {
     /// Adds a toolbar `Button` to mute or unmute text-to-speech capabilities.
     ///
-    /// When attaching the ``speechToolbarButton(enabled:muted:)`` modifier to a `View` that resides within a SwiftUI `NavigationStack`,
+    /// When attaching the ``speechToolbarButton(muted:)`` modifier to a `View` that resides within a SwiftUI `NavigationStack`,
     /// a `Button` is added to the toolbar that enables text-to-speech capabilities.
     /// The outside `View` is able to observe taps on that `Button` via passing in a SwiftUI `Binding` as the `muted` parameter, directly tracking the state of the `Button` but also being able to modify it from the outside.
     /// In addition, the button can be programatically hidden by adjusting the `enabled` parameter at any time.

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -12,7 +12,7 @@ import Foundation
 /// Represents the basic building block of a Spezi ``Chat``.
 ///
 /// A ``ChatEntity`` can be thought of as a single message entity within a ``Chat``
-/// It consists of a ``ChatEntity/Role``, a timestamp in the form of a `Date` as well as an `String`-based ``ChatEntity/content`` property which can contain Markdown-formatted text.
+/// It consists of a ``ChatEntity/Role``, a unique identifier, a timestamp in the form of a `Date` as well as an `String`-based ``ChatEntity/content`` property which can contain Markdown-formatted text.
 /// Furthermore, the ``ChatEntity/complete`` flag indicates if the current state of the ``ChatEntity`` is final and the content will not be updated anymore.
 public struct ChatEntity: Codable, Equatable, Hashable, Identifiable {
     /// Indicates which ``ChatEntity/Role`` is associated with a ``ChatEntity``.

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -33,16 +33,16 @@ public struct ChatEntity: Codable, Equatable, Hashable, Identifiable {
         }
     }
     
-    /// Unique identifier of the ``ChatEntity``.
-    public let id: UUID
     /// ``ChatEntity/Role`` associated with the ``ChatEntity``.
     public let role: Role
     /// `String`-based content of the ``ChatEntity``.
     public let content: String
-    /// The creation date of the ``ChatEntity``.
-    public let date: Date
     /// Indicates if the ``ChatEntity`` is complete and will not receive any additional content.
     public let complete: Bool
+    /// Unique identifier of the ``ChatEntity``.
+    public let id: UUID
+    /// The creation date of the ``ChatEntity``.
+    public let date: Date
     
     
     /// Markdown-formatted ``ChatEntity/content`` as an `AttributedString`, required to render the text in Markdown-style within the ``MessageView``.
@@ -66,11 +66,19 @@ public struct ChatEntity: Codable, Equatable, Hashable, Identifiable {
     ///    - role: ``ChatEntity/Role`` associated with the ``ChatEntity``.
     ///    - content: `String`-based content of the ``ChatEntity``. Can contain Markdown-formatted text.
     ///    - complete: Indicates if the content of the ``ChatEntity`` is complete and will not receive any additional content. Defaults to `true`.
-    public init<Content: StringProtocol>(role: Role, content: Content, complete: Bool = true) {
-        self.id = UUID()
+    ///    - id: Unique identifier of the ``ChatEntity``, defaults to a randomly assigned id.
+    ///    - date: Timestamp on when the ``ChatEntity`` was originally created, defaults to the current time.
+    public init<Content: StringProtocol>(
+        role: Role,
+        content: Content,
+        complete: Bool = true,
+        id: UUID = .init(),
+        date: Date = .now
+    ) {
         self.role = role
         self.content = String(content)
         self.complete = complete
-        self.date = Date()
+        self.id = id
+        self.date = date
     }
 }


### PR DESCRIPTION
# Make ID and Timestampbof ChatEntity configurable

## :recycle: Current situation & Problem
As of now, the id and timestamp of the `ChatEntity` are not configurable and are just initialized at allocation.


## :gear: Release Notes 
- Make ID and Timestampbof ChatEntity configurable


## :books: Documentation
Adjusted Docs


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
