### PR TITLE
Remove LLM semantics from Chat models

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ struct MessageViewTestView: View {
         VStack {
             MessageView(ChatEntity(role: .user, content: "User Message!"))
             MessageView(ChatEntity(role: .assistant, content: "Assistant Message!"))
-            MessageView(ChatEntity(role: .hidden(type: "system"), content: "System Message (hidden)!"))
+            MessageView(ChatEntity(role: .hidden(type: .unknown), content: "System Message (hidden)!"))
         }
             .padding()
     }

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ struct MessageViewTestView: View {
         VStack {
             MessageView(ChatEntity(role: .user, content: "User Message!"))
             MessageView(ChatEntity(role: .assistant, content: "Assistant Message!"))
-            MessageView(ChatEntity(role: .system, content: "System Message (hidden)!"))
+            MessageView(ChatEntity(role: .hidden(type: "system"), content: "System Message (hidden)!"))
         }
             .padding()
     }

--- a/Sources/SpeziChat/ChatView+Export.swift
+++ b/Sources/SpeziChat/ChatView+Export.swift
@@ -48,9 +48,15 @@ extension ChatView {
                                 .chatMessageStyle(alignment: chatEntity.alignment, backgroundColorUserChat: .blue)
                                 #endif
                             
-                            Text("\(chatEntity.role.rawValue.capitalized): \(chatEntity.date.formatted())")
-                                .font(.caption)
-                                .foregroundColor(.gray)
+                            if case .hidden(let type) = chatEntity.role {
+                                Text("\(type.name.capitalized) (hidden): \(chatEntity.date.formatted())")
+                                    .font(.caption)
+                                    .foregroundColor(.gray)
+                            } else {
+                                Text("\(chatEntity.role.rawValue.capitalized): \(chatEntity.date.formatted())")
+                                    .font(.caption)
+                                    .foregroundColor(.gray)
+                            }
                         }
                         if chatEntity.alignment == .leading {
                             Spacer(minLength: 32)

--- a/Sources/SpeziChat/ChatView+SpeechButton.swift
+++ b/Sources/SpeziChat/ChatView+SpeechButton.swift
@@ -88,11 +88,9 @@ extension View {
 #Preview {
     @State var chat: Chat = .init(
         [
-            ChatEntity(role: .system, content: "System Message!"),
-            ChatEntity(role: .system, content: "System Message (hidden)!"),
             ChatEntity(role: .user, content: "User Message!"),
+            ChatEntity(role: .hidden(type: "test"), content: "Hidden Message!"),
             ChatEntity(role: .assistant, content: "Assistant Message!"),
-            ChatEntity(role: .function(name: "test_function"), content: "Function Message!")
         ]
     )
     @State var muted = true

--- a/Sources/SpeziChat/ChatView+SpeechButton.swift
+++ b/Sources/SpeziChat/ChatView+SpeechButton.swift
@@ -89,8 +89,8 @@ extension View {
     @State var chat: Chat = .init(
         [
             ChatEntity(role: .user, content: "User Message!"),
-            ChatEntity(role: .hidden(type: "test"), content: "Hidden Message!"),
-            ChatEntity(role: .assistant, content: "Assistant Message!"),
+            ChatEntity(role: .hidden(type: .unknown), content: "Hidden Message!"),
+            ChatEntity(role: .assistant, content: "Assistant Message!")
         ]
     )
     @State var muted = true

--- a/Sources/SpeziChat/ChatView+SpeechOutput.swift
+++ b/Sources/SpeziChat/ChatView+SpeechOutput.swift
@@ -36,28 +36,24 @@ private struct ChatViewSpeechModifier: ViewModifier {
                     return
                 }
                 
-                Task {
-                    if lastChatEntity.role == .assistant {
-                        speechSynthesizer.speak(lastChatEntity.content)
-                    } else if lastChatEntity.role == .user {
-                        speechSynthesizer.stop()
-                    }
+                if lastChatEntity.role == .assistant {
+                    speechSynthesizer.speak(lastChatEntity.content)
+                } else if lastChatEntity.role == .user {
+                    speechSynthesizer.stop()
                 }
             }
              
             // Cancel speech output when muted button is tapped in the toolbar
             .onChange(of: muted) { _, newValue in
                 if newValue {
-                    Task {
-                        speechSynthesizer.stop()
-                    }
+                    speechSynthesizer.stop()
                 }
             }
             
             // Cancel speech output when view disappears
             .onChange(of: scenePhase) { _, newValue in
                 switch newValue {
-                case .background, .inactive: Task { speechSynthesizer.stop() }
+                case .background, .inactive: speechSynthesizer.stop()
                 default: break
                 }
             }

--- a/Sources/SpeziChat/ChatView+SpeechOutput.swift
+++ b/Sources/SpeziChat/ChatView+SpeechOutput.swift
@@ -109,11 +109,9 @@ extension View {
 #Preview("ChatView") {
     @State var chat: Chat = .init(
         [
-            ChatEntity(role: .system, content: "System Message!"),
-            ChatEntity(role: .system, content: "System Message (hidden)!"),
             ChatEntity(role: .user, content: "User Message!"),
+            ChatEntity(role: .hidden(type: "test"), content: "Hidden Message!"),
             ChatEntity(role: .assistant, content: "Assistant Message!"),
-            ChatEntity(role: .function(name: "test_function"), content: "Function Message!")
         ]
     )
     

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -37,7 +37,7 @@ import SwiftUI
 ///
 /// The ``ChatView`` provides speech-to-text (recognition) as well as text-to-speech (synthesize) capabilities out of the box via the [`SpeziSpeech`](https://github.com/StanfordSpezi/SpeziSpeech) module, facilitating seamless interaction with the content of the ``ChatView``.
 /// 
-/// Speech-to-text capabilities can be activated via the `speechToText` `Bool` parameter in ``init(_:disableInput:speechToText:exportFormat:messagePlaceholder:messagePendingAnimation:)``. By default, this capability is activated and therefore a small microphone button is shown next to the text input field.
+/// Speech-to-text capabilities can be activated via the `speechToText` `Bool` parameter in ``init(_:disableInput:speechToText:exportFormat:messagePlaceholder:messagePendingAnimation:hideMessages:)``. By default, this capability is activated and therefore a small microphone button is shown next to the text input field.
 ///
 /// Text-to-speech capabilities can be configured via the `View/speak(_:muted:)` `ViewModifier`. If present, the latest ``ChatEntity/complete`` ``ChatEntity/Role-swift.enum/assistant`` message in the ``Chat`` will be synthesized to natural language speech.
 /// In addition, the `View/speechToolbarButton(enabled:muted:)` `ViewModifier` automatically adds a toolbar `Button` to mute or unmute the speech synthesizer, if not disabled via the `enabled` parameter.
@@ -82,11 +82,12 @@ import SwiftUI
 /// ```
 public struct ChatView: View {
     @Binding var chat: Chat
-    private var disableInput: Bool
+    private let disableInput: Bool
     private let speechToText: Bool
     let exportFormat: ChatExportFormat?
     private let messagePlaceholder: String?
     private let messagePendingAnimation: MessagesView.TypingIndicatorDisplayMode?
+    private let hideMessages: MessageView.HiddenMessages
     
     @State private var messageInputHeight: CGFloat = 0
     @State private var showShareSheet = false
@@ -95,7 +96,7 @@ public struct ChatView: View {
     public var body: some View {
         ZStack {
             VStack {
-                MessagesView($chat, typingIndicator: messagePendingAnimation, bottomPadding: $messageInputHeight)
+                MessagesView($chat, hideMessages: hideMessages, typingIndicator: messagePendingAnimation, bottomPadding: $messageInputHeight)
                     #if !os(macOS)
                     .gesture(
                         TapGesture().onEnded {
@@ -177,19 +178,22 @@ public struct ChatView: View {
     ///   - exportFormat: If specified, enables the export of the ``Chat`` displayed in the ``ChatView`` via a share sheet in various formats defined in ``ChatView/ChatExportFormat``.
     ///   - messagePlaceholder: Placeholder text that should be added in the input field.
     ///   - messagePendingAnimation: Parameter to control whether a chat bubble animation is shown.
+    ///   - hideMessages: Types of ``ChatEntity/Role-swift.enum/hidden(type:)`` messages that should be hidden from the user.
     public init(
         _ chat: Binding<Chat>,
         disableInput: Bool = false,
         speechToText: Bool = true,
         exportFormat: ChatExportFormat? = nil,
         messagePlaceholder: String? = nil,
-        messagePendingAnimation: MessagesView.TypingIndicatorDisplayMode? = nil
+        messagePendingAnimation: MessagesView.TypingIndicatorDisplayMode? = nil,
+        hideMessages: MessageView.HiddenMessages = .all
     ) {
         self._chat = chat
         self.disableInput = disableInput
         self.speechToText = speechToText
         self.exportFormat = exportFormat
         self.messagePlaceholder = messagePlaceholder
+        self.hideMessages = hideMessages
         self.messagePendingAnimation = messagePendingAnimation
     }
 }

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -202,7 +202,7 @@ public struct ChatView: View {
             .constant(
                 [
                     ChatEntity(role: .user, content: "User Message!"),
-                    ChatEntity(role: .hidden(type: "test"), content: "Hidden Message!"),
+                    ChatEntity(role: .hidden(type: .unknown), content: "Hidden Message!"),
                     ChatEntity(role: .assistant, content: "Assistant Message!")
                 ]
             ),

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -202,8 +202,8 @@ public struct ChatView: View {
             .constant(
                 [
                     ChatEntity(role: .user, content: "User Message!"),
-                    ChatEntity(role: .assistant, content: "Assistant Message!"),
-                    ChatEntity(role: .hidden(type: "test"), content: "Hidden Message!")
+                    ChatEntity(role: .hidden(type: "test"), content: "Hidden Message!"),
+                    ChatEntity(role: .assistant, content: "Assistant Message!")
                 ]
             ),
             exportFormat: .pdf

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -201,11 +201,9 @@ public struct ChatView: View {
         ChatView(
             .constant(
                 [
-                    ChatEntity(role: .system, content: "System Message!"),
-                    ChatEntity(role: .system, content: "System Message (hidden)!"),
                     ChatEntity(role: .user, content: "User Message!"),
                     ChatEntity(role: .assistant, content: "Assistant Message!"),
-                    ChatEntity(role: .function(name: "test_function"), content: "Function Message!")
+                    ChatEntity(role: .hidden(type: "test"), content: "Hidden Message!")
                 ]
             ),
             exportFormat: .pdf

--- a/Sources/SpeziChat/Helpers/TypingIndicator.swift
+++ b/Sources/SpeziChat/Helpers/TypingIndicator.swift
@@ -32,14 +32,14 @@ public struct TypingIndicator: View {
             HStack(spacing: 3) {
                 ForEach(0..<3) { index in
                     Circle()
-                        .opacity(self.isAnimating ? 1 : 0)
+                        .opacity(isAnimating ? 1 : 0)
                         .foregroundStyle(.tertiary)
                         .animation(
                             Animation
                                 .easeInOut(duration: 0.6)
                                 .repeatForever(autoreverses: true)
                                 .delay(0.2 * Double(index)),
-                            value: self.isAnimating
+                            value: isAnimating
                         )
                         .frame(width: 10)
                 }
@@ -47,10 +47,10 @@ public struct TypingIndicator: View {
             }
                 .frame(width: 42, height: 12, alignment: .center)
                 .padding(.vertical, 4)
-                .onAppear {
-                    self.isAnimating = true
-                }
                 .chatMessageStyle(alignment: .leading)
+                .task {
+                    isAnimating = true
+                }
             
             Spacer(minLength: 32)
         }
@@ -62,10 +62,10 @@ public struct TypingIndicator: View {
 #Preview {
     ScrollView {
         VStack {
-            MessageView(ChatEntity(role: .system, content: "System Message!"), hideMessagesWithRoles: [])
-            MessageView(ChatEntity(role: .system, content: "System Message (hidden)!"))
-            MessageView(ChatEntity(role: .function(name: "test_function"), content: "Function Message!"), hideMessagesWithRoles: [.system])
             MessageView(ChatEntity(role: .user, content: "User Message!"))
+            MessageView(ChatEntity(role: .assistant, content: "Assistant Message!"))
+            MessageView(ChatEntity(role: .hidden(type: "test"), content: "Hidden Message!"))
+            MessageView(ChatEntity(role: .hidden(type: "test"), content: "Hidden Message! (still visible)"), hideMessagesWithRoles: [])
             TypingIndicator()
         }
         .padding()

--- a/Sources/SpeziChat/Helpers/TypingIndicator.swift
+++ b/Sources/SpeziChat/Helpers/TypingIndicator.swift
@@ -64,8 +64,14 @@ public struct TypingIndicator: View {
         VStack {
             MessageView(ChatEntity(role: .user, content: "User Message!"))
             MessageView(ChatEntity(role: .assistant, content: "Assistant Message!"))
-            MessageView(ChatEntity(role: .hidden(type: "test"), content: "Hidden Message!"))
-            MessageView(ChatEntity(role: .hidden(type: "test"), content: "Hidden Message! (still visible)"), hideMessagesWithRoles: [])
+            MessageView(ChatEntity(role: .hidden(type: .unknown), content: "Hidden Message!"))
+            MessageView(
+                ChatEntity(
+                    role: .hidden(type: .unknown),
+                    content: "Hidden message! (visible)"
+                ),
+                hideMessages: .custom(hiddenMessageTypes: [])
+            )
             TypingIndicator()
         }
         .padding()

--- a/Sources/SpeziChat/MessageInputView.swift
+++ b/Sources/SpeziChat/MessageInputView.swift
@@ -226,10 +226,8 @@ public struct MessageInputView: View {
 #if DEBUG
 #Preview {
     @State var chat = [
-        ChatEntity(role: .system, content: "System Message!"),
-        ChatEntity(role: .system, content: "System Message (hidden)!"),
-        ChatEntity(role: .function(name: "test_function"), content: "Function Message!"),
         ChatEntity(role: .user, content: "User Message!"),
+        ChatEntity(role: .hidden(type: "test"), content: "Hidden Message!"),
         ChatEntity(role: .assistant, content: "Assistant Message!")
     ]
     

--- a/Sources/SpeziChat/MessageInputView.swift
+++ b/Sources/SpeziChat/MessageInputView.swift
@@ -227,7 +227,7 @@ public struct MessageInputView: View {
 #Preview {
     @State var chat = [
         ChatEntity(role: .user, content: "User Message!"),
-        ChatEntity(role: .hidden(type: "test"), content: "Hidden Message!"),
+        ChatEntity(role: .hidden(type: .unknown), content: "Hidden Message!"),
         ChatEntity(role: .assistant, content: "Assistant Message!")
     ]
     

--- a/Sources/SpeziChat/MessageView.swift
+++ b/Sources/SpeziChat/MessageView.swift
@@ -21,7 +21,7 @@ import SwiftUI
 ///         VStack {
 ///             MessageView(ChatEntity(role: .user, content: "User Message!"))
 ///             MessageView(ChatEntity(role: .assistant, content: "Assistant Message!"))
-///             MessageView(ChatEntity(role: .hidden(type: "system"), content: "System Message (hidden)!"))
+///             MessageView(ChatEntity(role: .hidden(type: .unknown), content: "System Message (hidden)!"))
 ///         }
 ///             .padding()
 ///     }
@@ -54,7 +54,6 @@ public struct MessageView: View {
             return false
         }
     }
-    
     
     public var body: some View {
         if shouldDisplayMessage {

--- a/Sources/SpeziChat/MessageView.swift
+++ b/Sources/SpeziChat/MessageView.swift
@@ -11,8 +11,8 @@ import SwiftUI
 
 /// A reusable SwiftUI `View` to display the contents of a ``ChatEntity`` within a typical chat message bubble. This bubble is properly aligned according to the associated ``ChatEntity/Role``.
 ///
-/// Messages with specific system ``ChatEntity/Role``s are hidden. Those ``ChatEntity/Role``s are configurable via a parameter.
-/// 
+/// Messages with the ``ChatEntity/Role/hidden(type:)`` are hidden. These ``ChatEntity/Role``s are configurable via a parameter in the ``MessageView/init(_:hideMessagesWithRoles:)``.
+///
 /// ### Usage
 ///
 /// ```swift
@@ -21,7 +21,7 @@ import SwiftUI
 ///         VStack {
 ///             MessageView(ChatEntity(role: .user, content: "User Message!"))
 ///             MessageView(ChatEntity(role: .assistant, content: "Assistant Message!"))
-///             MessageView(ChatEntity(role: .system, content: "System Message (hidden)!"))
+///             MessageView(ChatEntity(role: .hidden(type: "system"), content: "System Message (hidden)!"))
 ///         }
 ///             .padding()
 ///     }
@@ -32,8 +32,7 @@ public struct MessageView: View {
     public enum Defaults {
         /// ``ChatEntity`` ``ChatEntity/Role``s that should be hidden by default
         public static let hideMessagesWithRoles: Set<ChatEntity.Role> = [
-            .system,
-            .function(name: "")     // Need to state a dummy associated value of the `ChatEntity/Role/function` case
+            .hidden(type: "")
         ]
     }
     
@@ -61,7 +60,7 @@ public struct MessageView: View {
     
     /// - Parameters:
     ///   - chat: The chat message that should be displayed.
-    ///   - hideMessagesWithRoles: If .system and/or .function messages should be hidden from the chat overview.
+    ///   - hideMessagesWithRoles: ``ChatEntity/Role-swift.enum``s that should be hidden from the user.
     public init(_ chat: ChatEntity, hideMessagesWithRoles: Set<ChatEntity.Role> = MessageView.Defaults.hideMessagesWithRoles) {
         self.chat = chat
         self.hideMessagesWithRoles = hideMessagesWithRoles
@@ -73,13 +72,12 @@ public struct MessageView: View {
 #Preview {
     ScrollView {
         VStack {
-            MessageView(ChatEntity(role: .system, content: "System Message!"), hideMessagesWithRoles: [])
-            MessageView(ChatEntity(role: .system, content: "System Message (hidden)!"))
-            MessageView(ChatEntity(role: .function(name: "test_function"), content: "Function Message!"), hideMessagesWithRoles: [.system])
             MessageView(ChatEntity(role: .user, content: "User Message!"))
             MessageView(ChatEntity(role: .assistant, content: "Assistant Message!"))
             MessageView(ChatEntity(role: .user, content: "Long User Message that spans over two lines!"))
             MessageView(ChatEntity(role: .assistant, content: "Long Assistant Message that spans over two lines!"))
+            MessageView(ChatEntity(role: .hidden(type: "test"), content: "Hidden message! (invisible)"))
+            MessageView(ChatEntity(role: .hidden(type: "test"), content: "Hidden message! (visible)"), hideMessagesWithRoles: [])
         }
             .padding()
     }

--- a/Sources/SpeziChat/MessagesView.swift
+++ b/Sources/SpeziChat/MessagesView.swift
@@ -72,7 +72,7 @@ public struct MessagesView: View {
         switch self.typingIndicator {
         case .automatic:
             switch self.chat.last?.role {
-            case .user, .function: true
+            case .user, .hidden: true
             default: false
             }
         case .manual(let shouldDisplay):
@@ -117,7 +117,7 @@ public struct MessagesView: View {
     ///   - chat: The chat messages that should be displayed.
     ///   - bottomPadding: A fixed bottom padding for the messages view.
     ///   - typingIndicator: Indicates whether a  "three dots" animation should be automatically or manually shown; default value of `nil` will result in no indicator being shown under any condition.
-    ///   - hideMessagesWithRoles: The .system and .function roles are hidden from message view
+    ///   - hideMessagesWithRoles: The ``ChatEntity/Role/hidden(type:)`` role messages are hidden from message view
     public init(
         _ chat: Chat,
         hideMessagesWithRoles: Set<ChatEntity.Role> = MessageView.Defaults.hideMessagesWithRoles,
@@ -160,10 +160,8 @@ public struct MessagesView: View {
 #Preview {
     MessagesView(
         [
-            ChatEntity(role: .system, content: "System Message!"),
-            ChatEntity(role: .system, content: "System Message (hidden)!"),
-            ChatEntity(role: .function(name: "test_function"), content: "Function Message!"),
             ChatEntity(role: .user, content: "User Message!"),
+            ChatEntity(role: .hidden(type: "test"), content: "Hidden Message!"),
             ChatEntity(role: .assistant, content: "Assistant Message!")
         ]
     )

--- a/Sources/SpeziChat/Models/ChatEntity+HiddenMessageType.swift
+++ b/Sources/SpeziChat/Models/ChatEntity+HiddenMessageType.swift
@@ -1,0 +1,29 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+extension ChatEntity {
+    /// The type of the ``Role-swift.enum/hidden(type:)`` message.
+    ///
+    /// ### Usage
+    ///
+    /// The ``ChatEntity/HiddenMessageType`` can be easily extended with new message types, even in different SPM targets or modules, via an extension, like:
+    /// ```swift
+    /// extension ChatEntity.HiddenMessageType {
+    ///     static let testType = HiddenMessageType(name: "testType")
+    /// }
+    /// ```
+    public struct HiddenMessageType: Codable, Equatable, Hashable {
+        /// The name of the type of the ``HiddenMessageType``.
+        public let name: String
+        
+        
+        /// Default ``HiddenMessageType``.
+        public static let unknown = HiddenMessageType(name: "unknown")
+    }
+}

--- a/Sources/SpeziChat/Models/ChatEntity+HiddenMessageType.swift
+++ b/Sources/SpeziChat/Models/ChatEntity+HiddenMessageType.swift
@@ -19,11 +19,19 @@ extension ChatEntity {
     /// }
     /// ```
     public struct HiddenMessageType: Codable, Equatable, Hashable {
+        /// Default ``HiddenMessageType``.
+        public static let unknown = HiddenMessageType(name: "unknown")
+        
+        
         /// The name of the type of the ``HiddenMessageType``.
         public let name: String
         
         
-        /// Default ``HiddenMessageType``.
-        public static let unknown = HiddenMessageType(name: "unknown")
+        /// Initializer of the ``ChatEntity/HiddenMessageType``
+        /// - Parameters:
+        ///     - name: The name of the hidden message type
+        public init(name: String) {
+            self.name = name
+        }
     }
 }

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -17,18 +17,16 @@ import Foundation
 public struct ChatEntity: Codable, Equatable, Hashable, Identifiable {
     /// Indicates which ``ChatEntity/Role`` is associated with a ``ChatEntity``.
     public enum Role: Codable, Equatable, Hashable {
-        case system
-        case assistant
         case user
-        case function(name: String)
+        case assistant
+        case hidden(type: String)
         
         
         var rawValue: String {
             switch self {
-            case .system: "system"
-            case .assistant: "assistant"
             case .user: "user"
-            case .function: "function"
+            case .assistant: "assistant"
+            case .hidden: "hidden"
             }
         }
     }

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -19,17 +19,18 @@ public struct ChatEntity: Codable, Equatable, Hashable, Identifiable {
     public enum Role: Codable, Equatable, Hashable {
         case user
         case assistant
-        case hidden(type: String)
+        case hidden(type: ChatEntity.HiddenMessageType)
         
         
         var rawValue: String {
             switch self {
             case .user: "user"
             case .assistant: "assistant"
-            case .hidden: "hidden"
+            case .hidden(let type): "hidden_\(type.name)"
             }
         }
     }
+    
     
     /// ``ChatEntity/Role`` associated with the ``ChatEntity``.
     public let role: Role

--- a/Sources/SpeziChat/Resources/Localizable.xcstrings
+++ b/Sources/SpeziChat/Resources/Localizable.xcstrings
@@ -1,6 +1,16 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "%@ (hidden): %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ (hidden): %2$@"
+          }
+        }
+      }
+    },
     "%@: %@" : {
       "localizations" : {
         "en" : {

--- a/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
+++ b/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
@@ -113,7 +113,7 @@ struct MessageViewTestView: View {
         VStack {
             MessageView(ChatEntity(role: .user, content: "User Message!"))
             MessageView(ChatEntity(role: .assistant, content: "Assistant Message!"))
-            MessageView(ChatEntity(role: .system, content: "System Message (hidden)!"))
+            MessageView(ChatEntity(role: .hidden(type: "system"), content: "System Message (hidden)!"))
         }
             .padding()
     }

--- a/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
+++ b/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
@@ -113,7 +113,7 @@ struct MessageViewTestView: View {
         VStack {
             MessageView(ChatEntity(role: .user, content: "User Message!"))
             MessageView(ChatEntity(role: .assistant, content: "Assistant Message!"))
-            MessageView(ChatEntity(role: .hidden(type: "system"), content: "System Message (hidden)!"))
+            MessageView(ChatEntity(role: .hidden(type: .unknown), content: "System Message (hidden)!"))
         }
             .padding()
     }
@@ -157,6 +157,8 @@ struct MessageInputTestView: View {
 
 - ``Chat``
 - ``ChatEntity``
+- ``ChatEntity/Role-swift.enum``
+- ``ChatEntity/HiddenMessageType``
 
 ### User input
 

--- a/Tests/UITests/TestApp/ChatTestView.swift
+++ b/Tests/UITests/TestApp/ChatTestView.swift
@@ -28,7 +28,7 @@ struct ChatTestView: View {
             .navigationTitle("SpeziChat")
             .padding(.top, 16)
             .onChange(of: chat) { _, newValue in
-                /// Append a new assistant message to the chat after sleeping for 5 seconds.
+                // Append a new assistant message to the chat after sleeping for 5 seconds.
                 if newValue.last?.role == .user {
                     Task {
                         try await Task.sleep(for: .seconds(5))

--- a/Tests/UITests/TestApp/ChatTestView.swift
+++ b/Tests/UITests/TestApp/ChatTestView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct ChatTestView: View {
     @State private var chat: Chat = [
+        ChatEntity(role: .hidden(type: .unknown), content: "Hidden Message!")
         ChatEntity(role: .assistant, content: "**Assistant** Message!")
     ]
     @State private var muted = true

--- a/Tests/UITests/TestApp/ChatTestView.swift
+++ b/Tests/UITests/TestApp/ChatTestView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 struct ChatTestView: View {
     @State private var chat: Chat = [
-        ChatEntity(role: .hidden(type: .unknown), content: "Hidden Message!")
+        ChatEntity(role: .hidden(type: .unknown), content: "Hidden Message!"),
         ChatEntity(role: .assistant, content: "**Assistant** Message!")
     ]
     @State private var muted = true


### PR DESCRIPTION
# Remove LLM semantics from Chat models

## :recycle: Current situation & Problem
As of now, SpeziChat contains some LLM semantics in the `Chat` and `ChatEntity` models. This mixes two different components that should live independent of each other.


## :gear: Release Notes 
- Remove LLM semantics from Chat models


## :books: Documentation
Updates documentation


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
