### PR TITLE
Add Tool Interaction Views

### DIFF
--- a/Sources/SpeziChat/ChatView+SpeechButton.swift
+++ b/Sources/SpeziChat/ChatView+SpeechButton.swift
@@ -86,14 +86,14 @@ extension View {
 
 #if DEBUG
 #Preview {
-    @State var chat: Chat = .init(
+    @Previewable @State var chat: Chat = .init(
         [
             ChatEntity(role: .user, content: "User Message!"),
             ChatEntity(role: .hidden(type: .unknown), content: "Hidden Message!"),
             ChatEntity(role: .assistant, content: "Assistant Message!")
         ]
     )
-    @State var muted = true
+    @Previewable @State var muted = true
     
     
     return NavigationStack {

--- a/Sources/SpeziChat/ChatView+SpeechOutput.swift
+++ b/Sources/SpeziChat/ChatView+SpeechOutput.swift
@@ -115,7 +115,7 @@ extension View {
 
 #if DEBUG
 #Preview("ChatView") {
-    @State var chat: Chat = .init(
+    @Previewable @State var chat: Chat = .init(
         [
             ChatEntity(role: .user, content: "User Message!"),
             ChatEntity(role: .hidden(type: .unknown), content: "Hidden Message!"),
@@ -129,12 +129,12 @@ extension View {
 }
 
 #Preview("ChatViewSpeechOutput") {
-    @State var chat: Chat = .init(
+    @Previewable @State var chat: Chat = .init(
         [
             ChatEntity(role: .assistant, content: "Assistant Message!")
         ]
     )
-    @State var muted = false
+    @Previewable @State var muted = false
     
     
     return NavigationStack {
@@ -144,12 +144,12 @@ extension View {
 }
 
 #Preview("ChatViewSpeechOutputDisabled") {
-    @State var chat: Chat = .init(
+    @Previewable @State var chat: Chat = .init(
         [
             ChatEntity(role: .assistant, content: "Assistant Message!")
         ]
     )
-    @State var muted = true
+    @Previewable @State var muted = true
     
     
     return NavigationStack {

--- a/Sources/SpeziChat/MessageInputView.swift
+++ b/Sources/SpeziChat/MessageInputView.swift
@@ -225,7 +225,7 @@ public struct MessageInputView: View {
 
 #if DEBUG
 #Preview {
-    @State var chat = [
+    @Previewable @State var chat = [
         ChatEntity(role: .user, content: "User Message!"),
         ChatEntity(role: .hidden(type: .unknown), content: "Hidden Message!"),
         ChatEntity(role: .assistant, content: "Assistant Message!")

--- a/Sources/SpeziChat/MessageView.swift
+++ b/Sources/SpeziChat/MessageView.swift
@@ -58,9 +58,9 @@ public struct MessageView: View {
     private var isToolInteraction: Bool {
         switch chat.role {
         case .assistantToolCall, .assistantToolResponse:
-            return true
+            true
         default:
-            return false
+            false
         }
     }
     

--- a/Sources/SpeziChat/MessagesView.swift
+++ b/Sources/SpeziChat/MessagesView.swift
@@ -175,6 +175,8 @@ public struct MessagesView: View {
         [
             ChatEntity(role: .user, content: "User Message!"),
             ChatEntity(role: .hidden(type: .unknown), content: "Hidden Message (but still visible)!"),
+            ChatEntity(role: .assistantToolCall, content: "Assistant Message!"),
+            ChatEntity(role: .assistantToolResponse, content: "Assistant Message!f jiodsjfiods \n fudshfdusi"),
             ChatEntity(role: .assistant, content: "Assistant Message!")
         ],
         hideMessages: .custom(hiddenMessageTypes: [])

--- a/Sources/SpeziChat/Models/ChatEntity+Alignment.swift
+++ b/Sources/SpeziChat/Models/ChatEntity+Alignment.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 
 extension ChatEntity {
@@ -24,6 +25,15 @@ extension ChatEntity {
             return .trailing
         default:
             return .leading
+        }
+    }
+    
+    var horziontalAlignment: HorizontalAlignment {
+        switch self.alignment {
+        case .leading:
+            return .leading
+        case .trailing:
+            return .trailing
         }
     }
 }

--- a/Sources/SpeziChat/Models/ChatEntity+Alignment.swift
+++ b/Sources/SpeziChat/Models/ChatEntity+Alignment.swift
@@ -22,18 +22,18 @@ extension ChatEntity {
     var alignment: Alignment {
         switch self.role {
         case .user:
-            return .trailing
+            .trailing
         default:
-            return .leading
+            .leading
         }
     }
     
     var horziontalAlignment: HorizontalAlignment {
         switch self.alignment {
         case .leading:
-            return .leading
+            .leading
         case .trailing:
-            return .trailing
+            .trailing
         }
     }
 }

--- a/Sources/SpeziChat/Models/ChatEntity.swift
+++ b/Sources/SpeziChat/Models/ChatEntity.swift
@@ -19,6 +19,8 @@ public struct ChatEntity: Codable, Equatable, Hashable, Identifiable {
     public enum Role: Codable, Equatable, Hashable {
         case user
         case assistant
+        case assistantToolCall
+        case assistantToolResponse
         case hidden(type: ChatEntity.HiddenMessageType)
         
         
@@ -26,6 +28,8 @@ public struct ChatEntity: Codable, Equatable, Hashable, Identifiable {
             switch self {
             case .user: "user"
             case .assistant: "assistant"
+            case .assistantToolCall: "assistant_tool_call"
+            case .assistantToolResponse: "assistant_tool_response"
             case .hidden(let type): "hidden_\(type.name)"
             }
         }

--- a/Sources/SpeziChat/Resources/Localizable.xcstrings
+++ b/Sources/SpeziChat/Resources/Localizable.xcstrings
@@ -75,6 +75,28 @@
         }
       }
     },
+    "SEE_MORE" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Details anzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Details"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver detalles"
+          }
+        }
+      }
+    },
     "SEND_MESSAGE" : {
       "localizations" : {
         "de" : {

--- a/Sources/SpeziChat/Resources/Localizable.xcstrings
+++ b/Sources/SpeziChat/Resources/Localizable.xcstrings
@@ -21,6 +21,9 @@
         }
       }
     },
+    "Equal sign" : {
+
+    },
     "EXPORT_CHAT_BUTTON" : {
       "localizations" : {
         "en" : {
@@ -30,6 +33,9 @@
           }
         }
       }
+    },
+    "Function F of X" : {
+
     },
     "MESSAGE_INPUT_TEXTFIELD" : {
       "localizations" : {

--- a/Sources/SpeziChat/Resources/Localizable.xcstrings
+++ b/Sources/SpeziChat/Resources/Localizable.xcstrings
@@ -21,21 +21,71 @@
         }
       }
     },
-    "Equal sign" : {
-
+    "EQUAL_SIGN" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gleichzeichen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Equal Sign"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signo igual"
+          }
+        }
+      }
     },
     "EXPORT_CHAT_BUTTON" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chat exportieren"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Export the Chat"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportar el chat"
+          }
         }
       }
     },
-    "Function F of X" : {
-
+    "FUNCTION_F_OF_X" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funktion F von X"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Function F of X"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Función F de X"
+          }
+        }
+      }
     },
     "MESSAGE_INPUT_TEXTFIELD" : {
       "localizations" : {
@@ -126,17 +176,55 @@
       }
     },
     "Text to speech is disabled, press to enable text to speech." : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Spracheingabe ist deaktiviert, tippe um die Eingabe zu aktivieren."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La función de texto a voz está desactivada, pulse para activarla."
+          }
+        }
+      }
     },
     "Text to speech is enabled, press to disable text to speech." : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Spracheingabe is aktiviert, tippe um die Eingabe zu dekativieren"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La función de texto a voz está activada, pulse para desactivarla."
+          }
+        }
+      }
     },
     "TYPING_INDICATOR" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schreibanzeige"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Typing Indicator"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indicador de mecanografía"
           }
         }
       }

--- a/Sources/SpeziChat/ToolInteractionView.swift
+++ b/Sources/SpeziChat/ToolInteractionView.swift
@@ -1,0 +1,81 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+/// The view that is represented when a tool call or tool reponse based on the ``ChatEntity/Role``.
+struct ToolInteractionView: View {
+    let entity: ChatEntity
+    @State private var isExpanded: Bool = false
+    
+    var body: some View {
+        switch entity.role {
+        case .assistantToolCall:
+            toolCallView(content: entity.content)
+        case .assistantToolResponse:
+            toolResponseView(content: entity.content)
+        default:
+            EmptyView()
+        }
+    }
+    
+    private func toolCallView(content: String) -> some View {
+        HStack {
+            Image(systemName: "function")
+                .frame(width: 20)
+            Text(content)
+                .foregroundStyle(.secondary)
+                .font(.footnote)
+                .lineLimit(isExpanded ? nil : 0)
+        }
+        .padding(.horizontal, 10)
+        .padding(.top, 8)
+        .onTapGesture {
+            withAnimation {
+                isExpanded.toggle()
+            }
+        }
+    }
+    
+    private func toolResponseView(content: String) -> some View {
+        HStack {
+            Image(systemName: "equal")
+                .frame(width: 20)
+            
+            Group {
+                if content.contains(where: \.isNewline) && !isExpanded {
+                    Text(String(localized: "SEE_MORE", bundle: .module))
+                        .italic()
+                } else {
+                    Text(content)
+                }
+            }
+            .foregroundStyle(.secondary)
+            .font(.footnote)
+            .lineLimit(isExpanded ? nil : 0)
+            
+        }
+        .padding(.horizontal, 10)
+        .padding(.top, 8)
+        .padding(.bottom, 4)
+        .onTapGesture {
+            withAnimation {
+                isExpanded.toggle()
+            }
+        }
+    }
+}
+
+#Preview {
+    ToolInteractionView(entity: .init(role: .assistantToolCall, content: "foo(bar: baz) This is a very long text that should be truncated"))
+    ToolInteractionView(entity: .init(role: .assistantToolResponse, content: """
+    {
+        "some": "response"
+    }
+    """))
+}

--- a/Sources/SpeziChat/ToolInteractionView.swift
+++ b/Sources/SpeziChat/ToolInteractionView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 /// The view that is represented when a tool call or tool reponse based on the ``ChatEntity/Role``.
 struct ToolInteractionView: View {
     let entity: ChatEntity
-    @State private var isExpanded: Bool = false
+    @State private var isExpanded = false
     
     var body: some View {
         switch entity.role {
@@ -27,6 +27,7 @@ struct ToolInteractionView: View {
     private func toolCallView(content: String) -> some View {
         HStack {
             Image(systemName: "function")
+                .accessibilityLabel("Function F of X")
                 .frame(width: 20)
             Text(content)
                 .foregroundStyle(.secondary)
@@ -45,6 +46,7 @@ struct ToolInteractionView: View {
     private func toolResponseView(content: String) -> some View {
         HStack {
             Image(systemName: "equal")
+                .accessibilityLabel("Equal sign")
                 .frame(width: 20)
             
             Group {
@@ -58,7 +60,6 @@ struct ToolInteractionView: View {
             .foregroundStyle(.secondary)
             .font(.footnote)
             .lineLimit(isExpanded ? nil : 0)
-            
         }
         .padding(.horizontal, 10)
         .padding(.top, 8)
@@ -69,13 +70,4 @@ struct ToolInteractionView: View {
             }
         }
     }
-}
-
-#Preview {
-    ToolInteractionView(entity: .init(role: .assistantToolCall, content: "foo(bar: baz) This is a very long text that should be truncated"))
-    ToolInteractionView(entity: .init(role: .assistantToolResponse, content: """
-    {
-        "some": "response"
-    }
-    """))
 }

--- a/Sources/SpeziChat/ToolInteractionView.swift
+++ b/Sources/SpeziChat/ToolInteractionView.swift
@@ -27,7 +27,7 @@ struct ToolInteractionView: View {
     private func toolCallView(content: String) -> some View {
         HStack {
             Image(systemName: "function")
-                .accessibilityLabel("Function F of X")
+                .accessibilityLabel("FUNCTION_F_OF_X")
                 .frame(width: 20)
             Text(content)
                 .foregroundStyle(.secondary)
@@ -46,7 +46,7 @@ struct ToolInteractionView: View {
     private func toolResponseView(content: String) -> some View {
         HStack {
             Image(systemName: "equal")
-                .accessibilityLabel("Equal sign")
+                .accessibilityLabel("EQUAL_SIGN")
                 .frame(width: 20)
             
             Group {

--- a/Tests/UITests/TestApp/ChatTestView.swift
+++ b/Tests/UITests/TestApp/ChatTestView.swift
@@ -34,15 +34,17 @@ struct ChatTestView: View {
                     Task {
                         try await Task.sleep(for: .seconds(3))
                         
-                        await MainActor.run {
-                            chat.append(.init(role: .assistantToolCall, content: "call_test_func({ test: true })"))
+                        if newValue.last?.content == "Call some function" {
+                            await MainActor.run {
+                                chat.append(.init(role: .assistantToolCall, content: "call_test_func({ test: true })"))
+                            }
+                            try await Task.sleep(for: .seconds(1))
+                            
+                            await MainActor.run {
+                                chat.append(.init(role: .assistantToolResponse, content: "{ some: response }"))
+                            }
+                            try await Task.sleep(for: .seconds(1))
                         }
-                        try await Task.sleep(for: .seconds(1))
-                        
-                        await MainActor.run {
-                            chat.append(.init(role: .assistantToolResponse, content: "{ some: response }"))
-                        }
-                        try await Task.sleep(for: .seconds(1))
                         
                         await MainActor.run {
                             chat.append(.init(role: .assistant, content: "**Assistant** Message Response!"))

--- a/Tests/UITests/TestApp/ChatTestView.swift
+++ b/Tests/UITests/TestApp/ChatTestView.swift
@@ -32,7 +32,17 @@ struct ChatTestView: View {
                 // Append a new assistant message to the chat after sleeping for 5 seconds.
                 if newValue.last?.role == .user {
                     Task {
-                        try await Task.sleep(for: .seconds(5))
+                        try await Task.sleep(for: .seconds(3))
+                        
+                        await MainActor.run {
+                            chat.append(.init(role: .assistantToolCall, content: "call_test_func({ test: true })"))
+                        }
+                        try await Task.sleep(for: .seconds(1))
+                        
+                        await MainActor.run {
+                            chat.append(.init(role: .assistantToolResponse, content: "{ some: response }"))
+                        }
+                        try await Task.sleep(for: .seconds(1))
                         
                         await MainActor.run {
                             chat.append(.init(role: .assistant, content: "**Assistant** Message Response!"))

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -154,4 +154,21 @@ class TestAppUITests: XCTestCase {
         XCTAssert(!app.buttons["Speaker strikethrough"].waitForExistence(timeout: 2))
         XCTAssert(app.buttons["Speaker"].waitForExistence(timeout: 2))
     }
+    
+    func testFunctionCallAndResponse() throws {
+        let app = XCUIApplication()
+        
+        XCTAssert(app.staticTexts["SpeziChat"].waitForExistence(timeout: 1))
+        XCTAssert(app.staticTexts["Assistant Message!"].waitForExistence(timeout: 1))
+        
+        try app.textFields["Message Input Textfield"].enter(value: "Call some function", dismissKeyboard: false)
+        XCTAssert(app.buttons["Send Message"].waitForExistence(timeout: 5))
+        app.buttons["Send Message"].tap()
+        
+        sleep(5)
+        
+        XCTAssert(app.staticTexts["call_test_func({ test: true })"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["{ some: response }"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Assistant Message Response!"].waitForExistence(timeout: 2))
+    }
 }

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -34,13 +34,9 @@ class TestAppUITests: XCTestCase {
         
         XCTAssert(app.staticTexts["User Message!"].waitForExistence(timeout: 5))
         
-        sleep(1)
+        XCTAssert(app.otherElements["Typing Indicator"].waitForExistence(timeout: 3))
         
-        XCTAssert(app.otherElements["Typing Indicator"].waitForExistence(timeout: 2))
-        
-        sleep(4)
-        
-        XCTAssert(app.staticTexts["Assistant Message Response!"].waitForExistence(timeout: 5))
+        XCTAssert(app.staticTexts["Assistant Message Response!"].waitForExistence(timeout: 9))
     }
     
     func testChatExport() throws {  // swiftlint:disable:this function_body_length

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -28,7 +28,7 @@ class TestAppUITests: XCTestCase {
         XCTAssert(app.staticTexts["SpeziChat"].waitForExistence(timeout: 1))
         XCTAssert(app.staticTexts["Assistant Message!"].waitForExistence(timeout: 1))
         
-        try app.textViews["Message Input Textfield"].enter(value: "User Message!", dismissKeyboard: false)
+        try app.textFields["Message Input Textfield"].enter(value: "User Message!", dismissKeyboard: false)
         XCTAssert(app.buttons["Send Message"].waitForExistence(timeout: 5))
         app.buttons["Send Message"].tap()
         
@@ -60,7 +60,7 @@ class TestAppUITests: XCTestCase {
             
             // Entering dummy chat value
             XCTAssert(app.staticTexts["SpeziChat"].waitForExistence(timeout: 1))
-            try app.textViews["Message Input Textfield"].enter(value: "User Message!", dismissKeyboard: false)
+            try app.textFields["Message Input Textfield"].enter(value: "User Message!", dismissKeyboard: false)
             XCTAssert(app.buttons["Send Message"].waitForExistence(timeout: 5))
             app.buttons["Send Message"].tap()
             

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -170,7 +170,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1500;
-				LastUpgradeCheck = 1500;
+				LastUpgradeCheck = 1610;
 				TargetAttributes = {
 					2F6D139128F5F384007C25D6 = {
 						CreatedOnToolsVersion = 14.1;
@@ -445,7 +445,6 @@
 		2F6D13BD28F5F386007C25D6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 637867499T;
@@ -470,7 +469,6 @@
 		2F6D13BE28F5F386007C25D6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 637867499T;
@@ -594,7 +592,6 @@
 		2FB07589299DDB6000C0B37F /* Test */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 637867499T;

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1610"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
# Add Tool Interaction Views

## :gear: Release Notes 
With this release we add two new roles `.assistantToolCall` and `.assistantToolResponse` which will be visible in the chat.
This will provides the user with additional context about the underlying techniques/functions used during the chat.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
