### PR TITLE
Use SpeziFoundation `runOrScheduleOnMainActor()`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "SpeziChat", targets: ["SpeziChat"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziSpeech", from: "1.1.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.8.0")
     ],

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ The [`MessageInputView`](https://swiftpackageindex.com/stanfordspezi/spezichat/d
 struct MessageInputTestView: View {
     @State private var chat: Chat = []
     @State private var disableInput = false
-    @State private var messageInputHeight: CGFloat = 0
     
     
     var body: some View {
@@ -137,7 +136,8 @@ struct MessageInputTestView: View {
                 .disabled(disableInput)
                 /// Get the height of the `MessageInputView` via a SwiftUI `PreferenceKey`
                 .onPreferenceChange(MessageInputViewHeightKey.self) { newValue in
-                    messageInputHeight = newValue
+                    let messageInputHeight: CGFloat = newValue
+                    // ...
                 }
         }
     }

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+import SpeziFoundation
 import SpeziSpeechSynthesizer
 import SwiftUI
 
@@ -115,18 +116,8 @@ public struct ChatView: View {
                 MessageInputView($chat, messagePlaceholder: messagePlaceholder, speechToText: speechToText)
                     .disabled(disableInput)
                     .onPreferenceChange(MessageInputViewHeightKey.self) { newValue in
-                        // The `onPreferenceChange` view modfier now takes a `@Sendable` closure, therefore we cannot capture `@MainActor` isolated properties
-                        // on the `View` directly anymore: https://developer.apple.com/documentation/swiftui/view/onpreferencechange(_:perform:)?changes=latest_minor
-                        // However, as the `@Sendable` closure is still run on the MainActor (at least in my testing on 18.2 RC SDKs), we can use `MainActor.assumeIsolated`
-                        // to avoid scheduling a `MainActor` `Task`, which could delay execution and cause unexpected UI behavior
-                        if Thread.isMainThread {
-                            MainActor.assumeIsolated {
-                                messageInputHeight = newValue + 12
-                            }
-                        } else {
-                            Task { @MainActor in
-                                messageInputHeight = newValue + 12
-                            }
+                        runOrScheduleOnMainActor {
+                            self.messageInputHeight = newValue + 12
                         }
                     }
             }

--- a/Sources/SpeziChat/MessageInputView.swift
+++ b/Sources/SpeziChat/MessageInputView.swift
@@ -27,9 +27,7 @@ import SwiftUI
 /// struct MessageInputTestView: View {
 ///     @State private var chat: Chat = []
 ///     @State private var disableInput = false
-///     /// Indicates the height of the input message field, necessary for properly shifting
-///     /// other view content.
-///     @State private var messageInputHeight: CGFloat = 0
+///
 ///
 ///     var body: some View {
 ///         VStack {
@@ -37,8 +35,10 @@ import SwiftUI
 ///             MessageInputView($chat, messagePlaceholder: "TestMessage")
 ///                 .disabled(disableInput)
 ///                 /// Get the height of the `MessageInputView` via a SwiftUI `PreferenceKey`
+///                 /// Indicates the height of the input message field, necessary for properly shifting other view content.
 ///                 .onPreferenceChange(MessageInputViewHeightKey.self) { newValue in
-///                     messageInputHeight = newValue
+///                     let messageInputHeight: CGFloat = newValue
+///                     // ...
 ///                 }
 ///         }
 ///     }

--- a/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
+++ b/Sources/SpeziChat/SpeziChat.docc/SpeziChat.md
@@ -128,7 +128,6 @@ The ``MessageInputView`` is a reusable SwiftUI `View` to handle text-based or sp
 struct MessageInputTestView: View {
     @State private var chat: Chat = []
     @State private var disableInput = false
-    @State private var messageInputHeight: CGFloat = 0
     
     
     var body: some View {
@@ -137,8 +136,10 @@ struct MessageInputTestView: View {
             MessageInputView($chat, messagePlaceholder: "TestMessage")
                 .disabled(disableInput)
                 /// Get the height of the `MessageInputView` via a SwiftUI `PreferenceKey`
+                /// Indicates the height of the input message field, necessary for properly shifting other view content.
                 .onPreferenceChange(MessageInputViewHeightKey.self) { newValue in
-                    messageInputHeight = newValue
+                    let messageInputHeight: CGFloat = newValue
+                    // ...
                 }
         }
     }


### PR DESCRIPTION
# Use SpeziFoundation `runOrScheduleOnMainActor()`

## :recycle: Current situation & Problem
Currently, SpeziChat manually checks and then runs or schedules (on the `MainActor`) `onPreferenceClosure()`s changes that modify `MainActor` isolated `State` properties in the SwiftUI `View`.
With StanfordSpezi/SpeziFoundation#18, this lengthy and repetitive code piece is now abstracted within SpeziFoundation.


## :gear: Release Notes 
- Use [SpeziFoundation `runOrScheduleOnMainActor()`](https://github.com/StanfordSpezi/SpeziFoundation/pull/18) function


## :books: Documentation
Proper documentation changes in DocC and Markdown.


## :white_check_mark: Testing
No new test cases added, as behavior stays strictly the same.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
