### PR TITLE
improved markdown rendering

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,6 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/SpeziSpeech.git", from: "1.1.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.8.0"),
         .package(url: "https://github.com/gonzalezreal/textual.git", from: "0.3.1")
-        
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,17 +16,19 @@ let package = Package(
     name: "SpeziChat",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
-        .visionOS(.v1),
-        .macOS(.v14)
+        .iOS(.v18),
+        .visionOS(.v2),
+        .macOS(.v15)
     ],
     products: [
         .library(name: "SpeziChat", targets: ["SpeziChat"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.1"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziSpeech", from: "1.1.1"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.8.0")
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.0.1"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziSpeech.git", from: "1.1.1"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.8.0"),
+        .package(url: "https://github.com/gonzalezreal/textual.git", from: "0.3.1")
+        
     ],
     targets: [
         .target(
@@ -35,7 +37,8 @@ let package = Package(
                 .product(name: "SpeziFoundation", package: "SpeziFoundation"),
                 .product(name: "SpeziSpeechRecognizer", package: "SpeziSpeech"),
                 .product(name: "SpeziSpeechSynthesizer", package: "SpeziSpeech"),
-                .product(name: "SpeziViews", package: "SpeziViews")
+                .product(name: "SpeziViews", package: "SpeziViews"),
+                .product(name: "Textual", package: "textual")
             ],
             resources: [
                 .process("Resources")

--- a/Sources/SpeziChat/ChatView+Export.swift
+++ b/Sources/SpeziChat/ChatView+Export.swift
@@ -29,7 +29,6 @@ extension ChatView {
     private struct ChatExportPDFView: View {
         let chat: Chat
         
-        
         var body: some View {
             VStack(spacing: 8) {    // The SwiftUI `ImageRenderer` doesn't support SwiftUI `List`s
                 ForEach(chat, id: \.self) { chatEntity in
@@ -38,6 +37,8 @@ extension ChatView {
                             Spacer(minLength: 32)
                         }
                         VStack(alignment: chatEntity.alignment == .leading ? .leading : .trailing) {
+                            // NOTE: we intentionally use a `Text` with an `AttributedString` here, instead of using `StructuredText` like in the MessageView,
+                            // the reason being that the `StructuredText` doesn't render properly during the PDF export.
                             Text(chatEntity.attributedContent)
                                 .fixedSize(horizontal: false, vertical: true)
                                 #if !os(visionOS)

--- a/Sources/SpeziChat/ChatView.swift
+++ b/Sources/SpeziChat/ChatView.swift
@@ -116,7 +116,8 @@ public struct ChatView: View {
                 MessageInputView($chat, messagePlaceholder: messagePlaceholder, speechToText: speechToText)
                     .disabled(disableInput)
                     .onPreferenceChange(MessageInputViewHeightKey.self) { newValue in
-                        runOrScheduleOnMainActor {
+                        Task { @MainActor in
+                            await Task.yield()
                             self.messageInputHeight = newValue + 12
                         }
                     }

--- a/Sources/SpeziChat/Helpers/TypingIndicator.swift
+++ b/Sources/SpeziChat/Helpers/TypingIndicator.swift
@@ -43,17 +43,17 @@ public struct TypingIndicator: View {
                         )
                         .frame(width: 10)
                 }
-                    .accessibilityIdentifier(String(localized: "TYPING_INDICATOR", bundle: .module))
             }
-                .frame(width: 42, height: 12, alignment: .center)
-                .padding(.vertical, 4)
-                .chatMessageStyle(alignment: .leading)
-                .task {
-                    isAnimating = true
-                }
-            
+            .frame(width: 42, height: 12, alignment: .center)
+            .padding(.vertical, 4)
+            .chatMessageStyle(alignment: .leading)
+            .task {
+                isAnimating = true
+            }
             Spacer(minLength: 32)
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text("TYPING_INDICATOR", bundle: .module))
     }
 }
 

--- a/Sources/SpeziChat/MessageView.swift
+++ b/Sources/SpeziChat/MessageView.swift
@@ -80,7 +80,6 @@ public struct MessageView: View {
                             .chatMessageStyle(alignment: chat.alignment)
                     }
                 }
-                
                 if chat.alignment == .leading {
                     Spacer(minLength: 32)
                 }

--- a/Sources/SpeziChat/MessageView.swift
+++ b/Sources/SpeziChat/MessageView.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import Textual
 
 
 /// A reusable SwiftUI `View` to display the contents of a ``ChatEntity`` within a typical chat message bubble. This bubble is properly aligned according to the associated ``ChatEntity/Role``.
@@ -74,7 +75,8 @@ public struct MessageView: View {
                     if isToolInteraction {
                         ToolInteractionView(entity: chat)
                     } else {
-                        Text(chat.attributedContent)
+                        StructuredText(markdown: chat.content)
+                            .textual.structuredTextStyle(.gitHub)
                             .chatMessageStyle(alignment: chat.alignment)
                     }
                 }

--- a/Tests/UITests/TestApp/ChatTestView.swift
+++ b/Tests/UITests/TestApp/ChatTestView.swift
@@ -29,29 +29,45 @@ struct ChatTestView: View {
             .navigationTitle("SpeziChat")
             .padding(.top, 16)
             .onChange(of: chat) { _, newValue in
-                // Append a new assistant message to the chat after sleeping for 5 seconds.
-                if newValue.last?.role == .user {
-                    Task {
-                        try await Task.sleep(for: .seconds(3))
-                        
-                        if newValue.last?.content == "Call some function" {
-                            await MainActor.run {
-                                chat.append(.init(role: .assistantToolCall, content: "call_test_func({ test: true })"))
-                            }
-                            try await Task.sleep(for: .seconds(1))
-                            
-                            await MainActor.run {
-                                chat.append(.init(role: .assistantToolResponse, content: "{ some: response }"))
-                            }
-                            try await Task.sleep(for: .seconds(1))
-                        }
-                        
-                        await MainActor.run {
-                            chat.append(.init(role: .assistant, content: "**Assistant** Message Response!"))
-                        }
-                    }
+                guard let message = newValue.last, message.role == .user else {
+                    return
+                }
+                Task {
+                    try await generateAssistantMessage(for: message)
                 }
             }
+    }
+    
+    private func generateAssistantMessage(for userMessage: ChatEntity) async throws {
+        // Append a new assistant message to the chat after sleeping for 5 seconds.
+        try await Task.sleep(for: .seconds(3))
+        if userMessage.content == "Call some function" {
+            chat.append(.init(role: .assistantToolCall, content: "call_test_func({ test: true })"))
+            try await Task.sleep(for: .seconds(1))
+            chat.append(.init(role: .assistantToolResponse, content: "{ some: response }"))
+            try await Task.sleep(for: .seconds(1))
+        } else if userMessage.content.localizedCaseInsensitiveContains("weather") {
+            chat.append(.init(role: .assistant, content: """
+                Here's the current weather snapshot:
+
+                | City | Temp | Condition |
+                |------|------|-----------|
+                | 🇩🇪 Munich | 41°F / 5°C | ❄️ Snow |
+                | 🇦🇹 Vienna | 42°F / 5°C | ☁️ Cloudy |
+                | 🇺🇸 San Francisco | 44°F / 7°C | ☁️ Cloudy |
+                | 🇬🇧 London | 55°F / 13°C | ☁️ Cloudy |
+                | 🇺🇸 New York City | 35°F / 2°C | ☀️ Sunny |
+                | 🇳🇴 Svalbard | 0°F / -18°C | 🌤️ Partly Sunny |
+                | 🇿🇦 Cape Town | 70°F / 21°C | 🌤️ Partly Sunny |
+                | 🇯🇵 Tokyo | — | ⚠️ Data unavailable |
+                | 🇨🇦 Toronto | 33°F / 1°C | ☁️ Cloudy |
+                | 🇫🇷 Paris | 56°F / 13°C | ☁️ Cloudy |
+
+                Tokyo's weather data returned an error — you may want to check a weather service directly for that one.
+                """))
+        } else {
+            chat.append(.init(role: .assistant, content: "**Assistant** Message Response!"))
+        }
     }
 }
 

--- a/Tests/UITests/TestApp/ChatTestView.swift
+++ b/Tests/UITests/TestApp/ChatTestView.swift
@@ -49,7 +49,7 @@ struct ChatTestView: View {
         } else if userMessage.content.localizedCaseInsensitiveContains("weather") {
             chat.append(.init(role: .assistant, content: """
                 Here's the current weather snapshot:
-
+                
                 | City | Temp | Condition |
                 |------|------|-----------|
                 | 🇩🇪 Munich | 41°F / 5°C | ❄️ Snow |
@@ -62,8 +62,19 @@ struct ChatTestView: View {
                 | 🇯🇵 Tokyo | — | ⚠️ Data unavailable |
                 | 🇨🇦 Toronto | 33°F / 1°C | ☁️ Cloudy |
                 | 🇫🇷 Paris | 56°F / 13°C | ☁️ Cloudy |
-
+                
                 Tokyo's weather data returned an error — you may want to check a weather service directly for that one.
+                """))
+        } else if userMessage.content.localizedCaseInsensitiveContains("fib") {
+            chat.append(.init(role: .assistant, content: """
+                ```rust
+                fn fib(n: u64) -> u64 {
+                    match n {
+                        0 | 1 => n,
+                        _ => fib(n - 1) + fib(n - 2)
+                    }
+                }
+                ```
                 """))
         } else {
             chat.append(.init(role: .assistant, content: "**Assistant** Message Response!"))

--- a/Tests/UITests/TestApp/ChatTestView.swift
+++ b/Tests/UITests/TestApp/ChatTestView.swift
@@ -39,7 +39,7 @@ struct ChatTestView: View {
     }
     
     private func generateAssistantMessage(for userMessage: ChatEntity) async throws {
-        try await Task.sleep(for: .seconds(2))
+        try await Task.sleep(for: .seconds(3))
         if userMessage.content.localizedCaseInsensitiveContains("call") {
             chat.append(.init(role: .assistantToolCall, content: "call_test_func({ test: true })"))
             try await Task.sleep(for: .seconds(1))

--- a/Tests/UITests/TestApp/ChatTestView.swift
+++ b/Tests/UITests/TestApp/ChatTestView.swift
@@ -39,13 +39,13 @@ struct ChatTestView: View {
     }
     
     private func generateAssistantMessage(for userMessage: ChatEntity) async throws {
-        // Append a new assistant message to the chat after sleeping for 5 seconds.
-        try await Task.sleep(for: .seconds(3))
-        if userMessage.content == "Call some function" {
+        try await Task.sleep(for: .seconds(2))
+        if userMessage.content.localizedCaseInsensitiveContains("call") {
             chat.append(.init(role: .assistantToolCall, content: "call_test_func({ test: true })"))
             try await Task.sleep(for: .seconds(1))
             chat.append(.init(role: .assistantToolResponse, content: "{ some: response }"))
             try await Task.sleep(for: .seconds(1))
+            chat.append(.init(role: .assistant, content: "**Assistant** Message Response!"))
         } else if userMessage.content.localizedCaseInsensitiveContains("weather") {
             chat.append(.init(role: .assistant, content: """
                 Here's the current weather snapshot:

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -140,8 +140,7 @@ class TestAppUITests: XCTestCase {
             guard preview.wait(for: .runningForeground, timeout: 3.0) else {
                 throw XCTSkip("The Preview App seems to fail on iOS 26 simulators; please double-check with furhter updates and re-activate.")
             }
-            
-            XCTAssert(preview.otherElements.containing(predicate).firstMatch.waitForExistence(timeout: 2))
+            XCTAssert(preview.staticTexts.matching(predicate).firstMatch.waitForExistence(timeout: 2))
         } else {
             XCTAssert(filesApp.otherElements.containing(predicate).firstMatch.waitForExistence(timeout: 5))
             // Close File in Files App

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -140,9 +140,9 @@ class TestAppUITests: XCTestCase {
             guard preview.wait(for: .runningForeground, timeout: 3.0) else {
                 throw XCTSkip("The Preview App seems to fail on iOS 26 simulators; please double-check with furhter updates and re-activate.")
             }
-            XCTAssert(preview.staticTexts.matching(predicate).firstMatch.waitForExistence(timeout: 2))
+            XCTAssert(preview.staticTexts.matching(predicate).firstMatch.waitForExistence(timeout: 10))
         } else {
-            XCTAssert(filesApp.otherElements.containing(predicate).firstMatch.waitForExistence(timeout: 5))
+            XCTAssert(filesApp.otherElements.containing(predicate).firstMatch.waitForExistence(timeout: 10))
             // Close File in Files App
             XCTAssert(filesApp.buttons["Done"].waitForExistence(timeout: 2))
             filesApp.buttons["Done"].tap()

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -128,7 +128,7 @@ class TestAppUITests: XCTestCase {
         XCTAssert(filesApp.collectionViews["File View"].cells["Exported Chat, pdf"].waitForExistence(timeout: 2))
         
         XCTAssert(filesApp.collectionViews["File View"].cells["Exported Chat, pdf"].images.firstMatch.waitForExistence(timeout: 2))
-        filesApp.collectionViews["File View"].cells["Exported Chat, pdf"].images.firstMatch.tap()
+        filesApp.collectionViews["File View"].cells["Exported Chat, pdf"].tap()
         
         // Check if PDF contains certain chat message
         let predicate = NSPredicate(format: "label CONTAINS[c] %@", "User Message!")

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -15,9 +15,7 @@ class TestAppUITests: XCTestCase {
     @MainActor
     override func setUp() async throws {
         try super.setUpWithError()
-        
         continueAfterFailure = false
-
         let app = XCUIApplication()
         app.launchArguments = ["--testMode"]
         app.launch()
@@ -30,16 +28,15 @@ class TestAppUITests: XCTestCase {
         XCTAssert(app.staticTexts["SpeziChat"].waitForExistence(timeout: 1))
         XCTAssert(app.staticTexts["Assistant Message!"].waitForExistence(timeout: 1))
         
-        try app.textFields["Message Input Textfield"].enter(value: "User Message!", dismissKeyboard: false)
-        XCTAssert(app.buttons["Send Message"].waitForExistence(timeout: 5))
+        try app.textFields["Message Input Textfield"].enter(value: "User Message!", options: [.disableKeyboardDismiss])
+        XCTAssert(app.buttons["Send Message"].waitForExistence(timeout: 2))
         app.buttons["Send Message"].tap()
-        
-        XCTAssert(app.staticTexts["User Message!"].waitForExistence(timeout: 5))
-        
-        XCTAssert(app.otherElements["Typing Indicator"].waitForExistence(timeout: 3))
-        
-        XCTAssert(app.staticTexts["Assistant Message Response!"].waitForExistence(timeout: 9))
+        XCTAssert(app.staticTexts["User Message!"].waitForExistence(timeout: 2))
+        XCTAssert(app.otherElements["Typing Indicator"].waitForExistence(timeout: 2))
+        XCTAssert(app.otherElements["Typing Indicator"].waitForNonExistence(timeout: 9))
+        XCTAssert(app.staticTexts["Assistant Message Response!"].waitForExistence(timeout: 2))
     }
+    
     
     func testChatExport() throws {  // swiftlint:disable:this function_body_length
         // Skip chat export test on visionOS and macOS
@@ -61,7 +58,7 @@ class TestAppUITests: XCTestCase {
             
             // Entering dummy chat value
             XCTAssert(app.staticTexts["SpeziChat"].waitForExistence(timeout: 1))
-            try app.textFields["Message Input Textfield"].enter(value: "User Message!", dismissKeyboard: false)
+            try app.textFields["Message Input Textfield"].enter(value: "User Message!", options: [.disableKeyboardDismiss])
             XCTAssert(app.buttons["Send Message"].waitForExistence(timeout: 5))
             app.buttons["Send Message"].tap()
             
@@ -175,7 +172,7 @@ class TestAppUITests: XCTestCase {
         XCTAssert(app.staticTexts["SpeziChat"].waitForExistence(timeout: 1))
         XCTAssert(app.staticTexts["Assistant Message!"].waitForExistence(timeout: 1))
         
-        try app.textFields["Message Input Textfield"].enter(value: "Call some function", dismissKeyboard: false)
+        try app.textFields["Message Input Textfield"].enter(value: "Call some function", options: [.disableKeyboardDismiss])
         XCTAssert(app.buttons["Send Message"].waitForExistence(timeout: 5))
         app.buttons["Send Message"].tap()
         

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -76,6 +76,8 @@ class TestAppUITests: XCTestCase {
             app.cells["XCElementSnapshotPrivilegedValuePlaceholder"].tap()
             #else
             XCTAssert(app.staticTexts["Save to Files"].waitForExistence(timeout: 10))
+            sleep(1) // we need to wait a little, since the check above will already resolve while the button is still being
+            // animated into position. if we tap too early it'll sometimes miss.
             app.staticTexts["Save to Files"].tap()
             #endif
 

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -3,14 +3,10 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2F6D139928F5F386007C25D6 /* Assets.xcassets */; };
-		2F8A431329130A8C005D2B8F /* TestAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A431229130A8C005D2B8F /* TestAppUITests.swift */; };
-		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
-		971D0E1D2B005DED003AD89E /* ChatTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 971D0E1C2B005DED003AD89E /* ChatTestView.swift */; };
 		971D0E1F2B005E9C003AD89E /* SpeziChat in Frameworks */ = {isa = PBXBuildFile; productRef = 971D0E1E2B005E9C003AD89E /* SpeziChat */; };
 		97911AFB2B01A27D003AEEF5 /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 97911AFA2B01A27D003AEEF5 /* XCTestExtensions */; };
 /* End PBXBuildFile section */
@@ -41,14 +37,15 @@
 /* Begin PBXFileReference section */
 		2F68C3C6292E9F8F00B3E12C /* SpeziChat */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SpeziChat; path = ../..; sourceTree = "<group>"; };
 		2F6D139228F5F384007C25D6 /* TestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		2F6D139928F5F386007C25D6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		2F8A431229130A8C005D2B8F /* TestAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppUITests.swift; sourceTree = "<group>"; };
-		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 		2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
-		971D0E1C2B005DED003AD89E /* ChatTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTestView.swift; sourceTree = "<group>"; };
 		9794D9552B01BC2200DC02FB /* Speech.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Speech.framework; path = System/Library/Frameworks/Speech.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		80A516762F49D9F1002AB920 /* TestAppUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = TestAppUITests; sourceTree = "<group>"; };
+		80A5167B2F49D9F4002AB920 /* TestApp */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = TestApp; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		2F6D138F28F5F384007C25D6 /* Frameworks */ = {
@@ -75,8 +72,8 @@
 			children = (
 				2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */,
 				2F68C3C6292E9F8F00B3E12C /* SpeziChat */,
-				2F6D139428F5F384007C25D6 /* TestApp */,
-				2F6D13AF28F5F386007C25D6 /* TestAppUITests */,
+				80A5167B2F49D9F4002AB920 /* TestApp */,
+				80A516762F49D9F1002AB920 /* TestAppUITests */,
 				2F6D139328F5F384007C25D6 /* Products */,
 				2F6D13C228F5F3BE007C25D6 /* Frameworks */,
 			);
@@ -89,24 +86,6 @@
 				2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		2F6D139428F5F384007C25D6 /* TestApp */ = {
-			isa = PBXGroup;
-			children = (
-				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
-				971D0E1C2B005DED003AD89E /* ChatTestView.swift */,
-				2F6D139928F5F386007C25D6 /* Assets.xcassets */,
-			);
-			path = TestApp;
-			sourceTree = "<group>";
-		};
-		2F6D13AF28F5F386007C25D6 /* TestAppUITests */ = {
-			isa = PBXGroup;
-			children = (
-				2F8A431229130A8C005D2B8F /* TestAppUITests.swift */,
-			);
-			path = TestAppUITests;
 			sourceTree = "<group>";
 		};
 		2F6D13C228F5F3BE007C25D6 /* Frameworks */ = {
@@ -133,6 +112,9 @@
 			);
 			dependencies = (
 			);
+			fileSystemSynchronizedGroups = (
+				80A5167B2F49D9F4002AB920 /* TestApp */,
+			);
 			name = TestApp;
 			packageProductDependencies = (
 				971D0E1E2B005E9C003AD89E /* SpeziChat */,
@@ -153,6 +135,9 @@
 			);
 			dependencies = (
 				2F6D13AE28F5F386007C25D6 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				80A516762F49D9F1002AB920 /* TestAppUITests */,
 			);
 			name = TestAppUITests;
 			packageProductDependencies = (
@@ -208,7 +193,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -226,8 +210,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				971D0E1D2B005DED003AD89E /* ChatTestView.swift in Sources */,
-				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -235,7 +217,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2F8A431329130A8C005D2B8F /* TestAppUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -366,12 +366,12 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezichat.testapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -383,6 +383,7 @@
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
@@ -405,12 +406,12 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezichat.testapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -422,6 +423,7 @@
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
@@ -553,12 +555,12 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezichat.testapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -570,6 +572,7 @@
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Test;
 		};

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -640,8 +640,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordBDHG/XCTestExtensions";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.10;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.2.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
# improved markdown rendering

## :recycle: Current situation & Problem
SpeziChat currently uses iOS's native markdown rendering (via `Text` and `AttributedString`), which is somewhat limited for the kinds of text blocks we expect to get back from LLMs.
for example, it doesn't support inline code blocks or tables.

this PR switches the `MessageView` to instead use the [textual](https://github.com/gonzalezreal/textual) library (which is the successor of the [swift-markdown-ui](https://github.com/gonzalezreal/swift-markdown-ui) currently used in several other Spezi packages)


## :gear: Release Notes
- MessageView: improved markdown rendering; support for tables/code/etc


## :books: Documentation
n/a


## :white_check_mark: Testing
no new tests, but the TestApp has been updated to produce tables and code blocks (if you ask for the weather, or ask it to write a `fib` function)


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
